### PR TITLE
Running on data

### DIFF
--- a/plugins/TestAnalyzer.cc
+++ b/plugins/TestAnalyzer.cc
@@ -1,12 +1,12 @@
 #include <cp3_llbb/Framework/interface/TestAnalyzer.h>
 
-#include <cp3_llbb/Framework/interface/GenParticlesProducer.h>
+//#include <cp3_llbb/Framework/interface/GenParticlesProducer.h>
 #include <cp3_llbb/Framework/interface/JetsProducer.h>
 
 
 void TestAnalyzer::analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager& producers) {
 
-    const GenParticlesProducer& gp = dynamic_cast<const GenParticlesProducer&>(producers.get("gen_particles"));
+//    const GenParticlesProducer& gp = dynamic_cast<const GenParticlesProducer&>(producers.get("gen_particles"));
     const JetsProducer& jets = dynamic_cast<const JetsProducer&>(producers.get("jets"));
 /*
     for (auto p4: gp.packed_p4) {

--- a/test/TestConfiguration.py
+++ b/test/TestConfiguration.py
@@ -8,13 +8,22 @@ process.load("Configuration.EventContent.EventContent_cff")
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 
-process.GlobalTag.globaltag = "MCRUN2_74_V9"
+#process.GlobalTag.globaltag = "MCRUN2_74_V9"
+process.GlobalTag.globaltag = "74X_dataRun2_Express_v0"
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(20))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 process.source = cms.Source("PoolSource")
 process.source.fileNames = cms.untracked.vstring(
-        'file:///home/fynu/sbrochet/storage/MINIAODSIM/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Asympt25ns_MCRUN2_74_V9_reduced.root'
+#        'file:///home/fynu/sbrochet/storage/MINIAODSIM/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Asympt25ns_MCRUN2_74_V9_reduced.root'
+'/store/data/Run2015B/DoubleMuon/MINIAOD/PromptReco-v1/000/251/244/00000/E42FEF61-6E27-E511-B93A-02163E0143C0.root',
+'/store/data/Run2015B/DoubleMuon/MINIAOD/PromptReco-v1/000/251/251/00000/0292F6F9-8A27-E511-9074-02163E012213.root',
+'/store/data/Run2015B/DoubleMuon/MINIAOD/PromptReco-v1/000/251/252/00000/9ADEE140-9C27-E511-919A-02163E011D23.root',
         )
+##### #####
+# Support for json files for data
+##### #####
+import FWCore.PythonUtilities.LumiList as LumiList
+process.source.lumisToProcess = LumiList.LumiList(filename = 'Cert_246908-251252_13TeV_PromptReco_Collisions15_JSON.txt').getVLuminosityBlockRange()
 ##### #####
 # Electron ID recipe
 ##### #####
@@ -35,7 +44,7 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 100
 
 # Producers
 from cp3_llbb.Framework import EventProducer
-from cp3_llbb.Framework import GenParticlesProducer
+#from cp3_llbb.Framework import GenParticlesProducer
 from cp3_llbb.Framework import HLTProducer
 from cp3_llbb.Framework import JetsProducer
 from cp3_llbb.Framework import METProducer
@@ -52,7 +61,7 @@ process.framework = cms.EDProducer("ExTreeMaker",
 
             hlt = HLTProducer.default_configuration,
 
-            gen_particles = GenParticlesProducer.default_configuration,
+#            gen_particles = GenParticlesProducer.default_configuration,
 
             jets = JetsProducer.default_configuration.clone(
                 parameters = cms.PSet(


### PR DESCRIPTION
Actually more for discussion rather than for merging, but I am not sure how else to share a running setup ? Anyhow, feedback : 
  * it seems that [just constructing the genparticle producer](https://github.com/cp3-llbb/Framework/compare/cp3-llbb:master...OlivierBondu:playing_with_data?expand=1#diff-1c35a03ced95ba4bf91dedce70c25171R9) crashes violently with some message similar to [1], not sure what happens exactly
  * other than that, it seems to run flawlessly :smile: (Job done in 345.872s ; 84874 processed events, 54447 selected)
  * next to do: check the output is not stupid

[1]
```
#6  0x00007fe925413b78 in ExTreeMaker::getProducer(std::string const&) () from /nfs/home/fynu/obondu/Higgs/CMSSW_7_4_5/lib/slc6_amd64_gcc491/libcp3_llbbFramework.so
#7  0x00007fe931f44b72 in TestAnalyzer::analyze(edm::Event const&, edm::EventSetup const&, ProducersManager const&) () from /nfs/home/fynu/obondu/Higgs/CMSSW_7_4_5/lib/slc6_amd64_gcc491/plugincp3_llbbFrameworkAuto.so
#8  0x00007fe92541339a in ExTreeMaker::produce(edm::Event&, edm::EventSetup const&) () from /nfs/home/fynu/obondu/Higgs/CMSSW_7_4_5/lib/slc6_amd64_gcc491/libcp3_llbbFramework.so
#9  0x00007fe94ac52239 in edm::EDProducer::doEvent(edm::EventPrincipal&, edm::EventSetup const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*) () from /cvmfs/cms.cern.ch/slc6_amd64_gcc491/cms/cmssw/CMSSW_7_4_5/lib/slc6_amd64_gcc491/libFWCoreFramework.so
```