### PR TITLE
Small cuts and categories refactoring

### DIFF
--- a/interface/Category.h
+++ b/interface/Category.h
@@ -16,7 +16,7 @@ class Category {
     public:
         virtual bool event_in_category(const ProducersManager& producers) const = 0;
         virtual void register_cuts(CutManager& manager) {};
-        virtual void evaluate_cuts(CutManager& manager) const {};
+        virtual void evaluate_cuts(CutManager& manager, const ProducersManager& producers) const {};
 };
 
 struct CategoryData {

--- a/interface/TestAnalyzer.h
+++ b/interface/TestAnalyzer.h
@@ -35,11 +35,10 @@ class TestAnalyzer: public Framework::Analyzer {
         virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&) override;
 
         virtual void registerCategories(CategoryManager& manager) {
-            manager.new_category("two_muons", "At least two muons category", &two_muons_category);
+            manager.new_category<TwoMuonsCategory>("two_muons", "At least two muons category");
         }
 
     private:
-        TwoMuonsCategory two_muons_category;
 
 };
 

--- a/interface/TestAnalyzer.h
+++ b/interface/TestAnalyzer.h
@@ -12,16 +12,17 @@ class TwoMuonsCategory: public Category {
     };
 
     virtual void register_cuts(CutManager& manager) override {
-        manager.new_cut("cut_1", "cut test");
-        manager.new_cut("cut_2", "cut test");
+        manager.new_cut("muon_1_pt", "pt > 30");
+        manager.new_cut("muon_2_pt", "pt > 10");
     };
 
-    virtual void evaluate_cuts(CutManager& manager) const override {
-        if (rand() / (float) RAND_MAX > 0.5)
-            manager.pass_cut("cut_1");
+    virtual void evaluate_cuts(CutManager& manager, const ProducersManager& producers) const override {
+        const MuonsProducer& muons = dynamic_cast<const MuonsProducer&>(producers.get("muons"));         
+        if (muons.p4[0].Pt() > 30) 
+            manager.pass_cut("muon_1_pt");
 
-        if (rand() / (float) RAND_MAX > 0.5)
-            manager.pass_cut("cut_2");
+        if (muons.p4[1].Pt() > 10)
+            manager.pass_cut("muon_2_pt");
     }
 };
 

--- a/src/Category.cc
+++ b/src/Category.cc
@@ -3,10 +3,6 @@
 #include <cstdio>
 #include <cinttypes>
 
-void CategoryManager::new_category(const std::string& name, const std::string& description, Category* category) {
-    m_categories.push_back(CategoryData(name, description, category, m_tree));
-}
-
 bool CategoryManager::evaluate(const ProducersManager& producers) {
     bool ret;
 

--- a/src/Category.cc
+++ b/src/Category.cc
@@ -15,7 +15,7 @@ bool CategoryManager::evaluate(const ProducersManager& producers) {
                 ret = true;
                 category.in_category = true;
                 category.events++;
-                category.callback->evaluate_cuts(category.cut_manager);
+                category.callback->evaluate_cuts(category.cut_manager, producers);
             }
         }
     }


### PR DESCRIPTION
This is a (very) small refactoring for category creations as well as a fix for cuts usage.

- ``new_category`` is now a templated function of the Category class type. Now need anymore to pass a pointer to the category class. Instantiation of the class is done internally

Before:

    manager.new_category("two_muons", "At least two muons category", &two_muons_category);

Now:

    manager.new_category<TwoMuonsCategory>("two_muons", "At least two muons category");

 - The ``evaluate_cuts`` function takes now a ``ProducersManager`` as 2nd argument. It's now possible to do something useful in that function.