### PR TITLE
Make ProducersManager::get templated

### DIFF
--- a/interface/Framework.h
+++ b/interface/Framework.h
@@ -12,9 +12,10 @@
 #include "cp3_llbb/Framework/interface/Analyzer.h"
 #include "cp3_llbb/Framework/interface/Producer.h"
 #include "cp3_llbb/Framework/interface/Category.h"
+#include "cp3_llbb/Framework/interface/ProducerGetter.h"
 #include "cp3_llbb/Framework/interface/ProducersManager.h"
 
-class ExTreeMaker: public edm::EDProducer {
+class ExTreeMaker: public edm::EDProducer, ProducerGetter {
     friend class ProducersManager;
 
     public:
@@ -32,9 +33,9 @@ class ExTreeMaker: public edm::EDProducer {
         virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
         virtual void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
-        // For ProducersManager
-        Framework::Producer& getProducer(const std::string& name);
-        bool producerExists(const std::string& name);
+        // From ProducerGetter
+        virtual const Framework::Producer& getProducer(const std::string& name) const override;
+        virtual bool producerExists(const std::string& name) const override;
         std::unique_ptr<ProducersManager> m_producers_manager;
 
         std::string m_output_filename;

--- a/interface/ProducerGetter.h
+++ b/interface/ProducerGetter.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+namespace Framework {
+    class Producer;
+};
+
+class ProducerGetter {
+    public:
+        virtual const Framework::Producer& getProducer(const std::string& name) const = 0;
+        virtual bool producerExists(const std::string& name) const = 0;
+};

--- a/interface/ProducersManager.h
+++ b/interface/ProducersManager.h
@@ -1,24 +1,27 @@
 #ifndef PRODUCERS_MANAGER
 #define PRODUCERS_MANAGER
 
+#include "cp3_llbb/Framework/interface/ProducerGetter.h"
+#include "cp3_llbb/Framework/interface/Producer.h"
+
 #include <string>
-
-namespace Framework {
-    class Producer;
-};
-
-class ExTreeMaker;
+#include <type_traits>
 
 class ProducersManager {
     friend class ExTreeMaker;
 
     public:
-        const Framework::Producer& get(const std::string& name) const;
-        bool exists(const std::string& name) const;
+    template <class T>
+        const T& get(const std::string& name) const {
+            static_assert(std::is_base_of<Framework::Producer, T>::value, "T must inherit from Framework::Producer");
+            return dynamic_cast<const T&>(m_getter.getProducer(name));
+        }
+
+    bool exists(const std::string& name) const;
 
     private:
-        ProducersManager(ExTreeMaker* framework);
-        ExTreeMaker* m_framework;
+    ProducersManager(const ProducerGetter& getter);
+    const ProducerGetter& m_getter;
 
 };
 

--- a/interface/TestAnalyzer.h
+++ b/interface/TestAnalyzer.h
@@ -7,7 +7,7 @@
 
 class TwoMuonsCategory: public Category {
     virtual bool event_in_category(const ProducersManager& producers) const override {
-        const MuonsProducer& muons = dynamic_cast<const MuonsProducer&>(producers.get("muons"));         
+        const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
         return muons.p4.size() >= 2;
     };
 
@@ -17,7 +17,7 @@ class TwoMuonsCategory: public Category {
     };
 
     virtual void evaluate_cuts(CutManager& manager, const ProducersManager& producers) const override {
-        const MuonsProducer& muons = dynamic_cast<const MuonsProducer&>(producers.get("muons"));         
+        const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
         if (muons.p4[0].Pt() > 30) 
             manager.pass_cut("muon_1_pt");
 

--- a/plugins/TestAnalyzer.cc
+++ b/plugins/TestAnalyzer.cc
@@ -6,7 +6,7 @@
 
 void TestAnalyzer::analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager& producers) {
 
-    const JetsProducer& jets = dynamic_cast<const JetsProducer&>(producers.get("jets"));
+    const JetsProducer& jets = producers.get<JetsProducer>("jets");
 
 /*
     if (producers.exists("gen_particles")) {

--- a/src/Framework.cc
+++ b/src/Framework.cc
@@ -33,7 +33,7 @@ ExTreeMaker::ExTreeMaker(const edm::ParameterSet& iConfig):
         m_wrapper.reset(new ROOT::TreeWrapper(tree));
 
         m_categories.reset(new CategoryManager(*m_wrapper));
-        m_producers_manager.reset(new ProducersManager(this));
+        m_producers_manager.reset(new ProducersManager(*this));
 
         // Load plugins
         if (!iConfig.existsAs<edm::ParameterSet>("producers")) {
@@ -172,7 +172,7 @@ void ExTreeMaker::endLuminosityBlock(const edm::LuminosityBlock& lumi, const edm
         analyzer->endLuminosityBlock(lumi, eventSetup);
 }
 
-Framework::Producer& ExTreeMaker::getProducer(const std::string& name) {
+const Framework::Producer& ExTreeMaker::getProducer(const std::string& name) const {
     const auto& producer = m_producers.find(name);
     if (producer == m_producers.end()) {
         std::stringstream details;
@@ -183,7 +183,7 @@ Framework::Producer& ExTreeMaker::getProducer(const std::string& name) {
     return *producer->second;
 }
 
-bool ExTreeMaker::producerExists(const std::string& name) {
+bool ExTreeMaker::producerExists(const std::string& name) const {
     const auto& producer = m_producers.find(name);
     return (producer != m_producers.end());
 }

--- a/src/ProducersManager.cc
+++ b/src/ProducersManager.cc
@@ -1,17 +1,10 @@
 #include <cp3_llbb/Framework/interface/ProducersManager.h>
 
-#include <cp3_llbb/Framework/interface/Framework.h>
-#include <cp3_llbb/Framework/interface/Producer.h>
-
-ProducersManager::ProducersManager(ExTreeMaker* framework):
-    m_framework(framework) {
+ProducersManager::ProducersManager(const ProducerGetter& getter):
+    m_getter(getter) {
         // Empty
 }
 
-const Framework::Producer& ProducersManager::get(const std::string& name) const {
-    return m_framework->getProducer(name);
-}
-
 bool ProducersManager::exists(const std::string& name) const {
-    return m_framework->producerExists(name);
+    return m_getter.producerExists(name);
 }


### PR DESCRIPTION
It's a small improvement for ``ProducersManager``. Instead of letting the user do the ugly const dynamic cast to the right type, let the function do it for him.

Old syntax:

```C++
const MuonsProducer& muons = dynamic_cast<const MuonsProducer&>(producers.get("muons"));
```

New syntax:
```C++
const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
```

A compile-time check is done to be sure that the class used inherit from ``Framework::Producer``. As a bonus, this PR also breaks the circular dependency between ``Framework`` and ``ProducersManager`` :smile_cat: 

**Note**: this will most likely break all the existing analyzers, so better doing it now than later :smile: 