### PR TITLE
Improvement of categories

### DIFF
--- a/interface/Analyzer.h
+++ b/interface/Analyzer.h
@@ -10,7 +10,6 @@
 #include <FWCore/Framework/interface/ConsumesCollector.h>
 #include <FWCore/Utilities/interface/InputTag.h>
 
-#include <cp3_llbb/Framework/interface/Category.h>
 #include <cp3_llbb/Framework/interface/ProducersManager.h>
 #include <cp3_llbb/TreeWrapper/interface/TreeWrapper.h>
 
@@ -20,6 +19,8 @@
 #include <map>
 
 typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float>> LorentzVector;
+
+class CategoryManager;
 
 namespace Framework {
 

--- a/interface/AnalyzerGetter.h
+++ b/interface/AnalyzerGetter.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+namespace Framework {
+    class Analyzer;
+};
+
+class AnalyzerGetter {
+    public:
+        virtual const Framework::Analyzer& getAnalyzer(const std::string& name) const = 0;
+        virtual bool analyzerExists(const std::string& name) const = 0;
+};

--- a/interface/AnalyzersManager.h
+++ b/interface/AnalyzersManager.h
@@ -1,0 +1,28 @@
+#ifndef ANALYZERS_MANAGER
+#define ANALYZERS_MANAGER
+
+#include "cp3_llbb/Framework/interface/AnalyzerGetter.h"
+#include "cp3_llbb/Framework/interface/Analyzer.h"
+
+#include <string>
+#include <type_traits>
+
+class AnalyzersManager {
+    friend class ExTreeMaker;
+
+    public:
+        template <class T>
+            const T& get(const std::string& name) const {
+                static_assert(std::is_base_of<Framework::Analyzer, T>::value, "T must inherit from Framework::Analyzer");
+                return dynamic_cast<const T&>(m_getter.getAnalyzer(name));
+            }
+
+        bool exists(const std::string& name) const;
+
+    private:
+        AnalyzersManager(const AnalyzerGetter& getter);
+        const AnalyzerGetter& m_getter;
+
+};
+
+#endif

--- a/interface/Category.h
+++ b/interface/Category.h
@@ -7,6 +7,7 @@
 
 #include <cp3_llbb/Framework/interface/Cut.h>
 #include <cp3_llbb/Framework/interface/ProducersManager.h>
+#include <cp3_llbb/Framework/interface/AnalyzersManager.h>
 
 #include <cp3_llbb/TreeWrapper/interface/TreeWrapper.h>
 
@@ -14,9 +15,13 @@ class CategoryManager;
 
 class Category {
     public:
-        virtual bool event_in_category(const ProducersManager& producers) const = 0;
+        virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const = 0;
+        virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const = 0;
+
         virtual void register_cuts(CutManager& manager) {};
-        virtual void evaluate_cuts(CutManager& manager, const ProducersManager& producers) const {};
+
+        virtual void evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const {};
+        virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {};
 };
 
 struct CategoryData {
@@ -29,6 +34,8 @@ struct CategoryData {
     uint64_t events = 0;
 
     // Tree branches
+    bool in_category_pre = false;
+    bool in_category_post = false;
     bool& in_category;
 
     CategoryData(const std::string& name_, const std::string& description_, std::unique_ptr<Category> category, ROOT::TreeWrapper& tree_):
@@ -53,7 +60,10 @@ class CategoryManager {
             m_categories.push_back(CategoryData(name, description, std::move(category), m_tree));
         }
 
-        bool evaluate(const ProducersManager& producers);
+        bool evaluate_pre_analyzers(const ProducersManager& producers);
+        bool evaluate_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers);
+
+        void reset();
 
         void print_summary();
 

--- a/interface/Framework.h
+++ b/interface/Framework.h
@@ -12,9 +12,10 @@
 #include "cp3_llbb/Framework/interface/Analyzer.h"
 #include "cp3_llbb/Framework/interface/Producer.h"
 #include "cp3_llbb/Framework/interface/Category.h"
+#include "cp3_llbb/Framework/interface/ProducerGetter.h"
 #include "cp3_llbb/Framework/interface/ProducersManager.h"
 
-class ExTreeMaker: public edm::EDProducer {
+class ExTreeMaker: public edm::EDProducer, ProducerGetter {
     friend class ProducersManager;
 
     public:
@@ -32,9 +33,9 @@ class ExTreeMaker: public edm::EDProducer {
         virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
         virtual void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
-        // For ProducersManager
-        Framework::Producer& getProducer(const std::string& name);
-        bool producerExists(const std::string& name);
+        // From ProducerGetter
+        virtual const Framework::Producer& getProducer(const std::string& name) const override;
+        virtual bool producerExists(const std::string& name) const override;
         std::unique_ptr<ProducersManager> m_producers_manager;
 
         std::string m_output_filename;

--- a/interface/Framework.h
+++ b/interface/Framework.h
@@ -14,9 +14,12 @@
 #include "cp3_llbb/Framework/interface/Category.h"
 #include "cp3_llbb/Framework/interface/ProducerGetter.h"
 #include "cp3_llbb/Framework/interface/ProducersManager.h"
+#include "cp3_llbb/Framework/interface/AnalyzerGetter.h"
+#include "cp3_llbb/Framework/interface/AnalyzersManager.h"
 
-class ExTreeMaker: public edm::EDProducer, ProducerGetter {
+class ExTreeMaker: public edm::EDProducer, ProducerGetter, AnalyzerGetter {
     friend class ProducersManager;
+    friend class AnalyzersManager;
 
     public:
         explicit ExTreeMaker(const edm::ParameterSet&);
@@ -38,11 +41,20 @@ class ExTreeMaker: public edm::EDProducer, ProducerGetter {
         virtual bool producerExists(const std::string& name) const override;
         std::unique_ptr<ProducersManager> m_producers_manager;
 
+        // From AnalyzerGetter
+        virtual const Framework::Analyzer& getAnalyzer(const std::string& name) const override;
+        virtual bool analyzerExists(const std::string& name) const override;
+        std::unique_ptr<AnalyzersManager> m_analyzers_manager;
+
         std::string m_output_filename;
         std::unique_ptr<TFile> m_output;
         std::unique_ptr<ROOT::TreeWrapper> m_wrapper;
         std::unordered_map<std::string, std::shared_ptr<Framework::Producer>> m_producers;
+
+
+        // Order is important, we can't use a map here
         std::vector<std::shared_ptr<Framework::Analyzer>> m_analyzers;
+        std::vector<std::string> m_analyzers_name;
 
         // Categories
         std::unique_ptr<CategoryManager> m_categories;

--- a/interface/ProducerGetter.h
+++ b/interface/ProducerGetter.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+namespace Framework {
+    class Producer;
+};
+
+class ProducerGetter {
+    public:
+        virtual const Framework::Producer& getProducer(const std::string& name) const = 0;
+        virtual bool producerExists(const std::string& name) const = 0;
+};

--- a/interface/ProducersManager.h
+++ b/interface/ProducersManager.h
@@ -1,24 +1,27 @@
 #ifndef PRODUCERS_MANAGER
 #define PRODUCERS_MANAGER
 
+#include "cp3_llbb/Framework/interface/ProducerGetter.h"
+#include "cp3_llbb/Framework/interface/Producer.h"
+
 #include <string>
-
-namespace Framework {
-    class Producer;
-};
-
-class ExTreeMaker;
+#include <type_traits>
 
 class ProducersManager {
     friend class ExTreeMaker;
 
     public:
-        const Framework::Producer& get(const std::string& name) const;
-        bool exists(const std::string& name) const;
+    template <class T>
+        const T& get(const std::string& name) const {
+            static_assert(std::is_base_of<Framework::Producer, T>::value, "T must inherit from Framework::Producer");
+            return dynamic_cast<const T&>(m_getter.getProducer(name));
+        }
+
+    bool exists(const std::string& name) const;
 
     private:
-        ProducersManager(ExTreeMaker* framework);
-        ExTreeMaker* m_framework;
+    ProducersManager(const ProducerGetter& getter);
+    const ProducerGetter& m_getter;
 
 };
 

--- a/interface/TestAnalyzer.h
+++ b/interface/TestAnalyzer.h
@@ -2,13 +2,18 @@
 #define TESTANALYZER_H
 
 #include <cp3_llbb/Framework/interface/Analyzer.h>
+#include <cp3_llbb/Framework/interface/Category.h>
 
 #include <cp3_llbb/Framework/interface/MuonsProducer.h>
 
 class TwoMuonsCategory: public Category {
-    virtual bool event_in_category(const ProducersManager& producers) const override {
+    virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override {
         const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
         return muons.p4.size() >= 2;
+    };
+
+    virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override {
+        return true;
     };
 
     virtual void register_cuts(CutManager& manager) override {
@@ -16,7 +21,7 @@ class TwoMuonsCategory: public Category {
         manager.new_cut("muon_2_pt", "pt > 10");
     };
 
-    virtual void evaluate_cuts(CutManager& manager, const ProducersManager& producers) const override {
+    virtual void evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const override {
         const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
         if (muons.p4[0].Pt() > 30) 
             manager.pass_cut("muon_1_pt");

--- a/interface/TestAnalyzer.h
+++ b/interface/TestAnalyzer.h
@@ -7,7 +7,7 @@
 
 class TwoMuonsCategory: public Category {
     virtual bool event_in_category(const ProducersManager& producers) const override {
-        const MuonsProducer& muons = dynamic_cast<const MuonsProducer&>(producers.get("muons"));         
+        const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
         return muons.p4.size() >= 2;
     };
 
@@ -17,7 +17,7 @@ class TwoMuonsCategory: public Category {
     };
 
     virtual void evaluate_cuts(CutManager& manager, const ProducersManager& producers) const override {
-        const MuonsProducer& muons = dynamic_cast<const MuonsProducer&>(producers.get("muons"));         
+        const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
         if (muons.p4[0].Pt() > 30) 
             manager.pass_cut("muon_1_pt");
 

--- a/plugins/TestAnalyzer.cc
+++ b/plugins/TestAnalyzer.cc
@@ -6,7 +6,7 @@
 
 void TestAnalyzer::analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager& producers) {
 
-    const JetsProducer& jets = dynamic_cast<const JetsProducer&>(producers.get("jets"));
+    const JetsProducer& jets = producers.get<JetsProducer>("jets");
 
 /*
     if (producers.exists("gen_particles")) {

--- a/src/AnalyzersManager.cc
+++ b/src/AnalyzersManager.cc
@@ -1,0 +1,10 @@
+#include <cp3_llbb/Framework/interface/AnalyzersManager.h>
+
+AnalyzersManager::AnalyzersManager(const AnalyzerGetter& getter):
+    m_getter(getter) {
+        // Empty
+}
+
+bool AnalyzersManager::exists(const std::string& name) const {
+    return m_getter.analyzerExists(name);
+}

--- a/src/Framework.cc
+++ b/src/Framework.cc
@@ -103,13 +103,21 @@ void ExTreeMaker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     for (auto& producer: m_producers)
         producer.second->produce(iEvent, iSetup);
 
+    bool should_continue = m_categories->evaluate_pre_analyzers(*m_producers_manager);
+    if (! should_continue) {
+        m_wrapper->reset();
+        m_categories->reset();
+    }
+
     for (auto& analyzer: m_analyzers)
         analyzer->analyze(iEvent, iSetup, *m_producers_manager);
 
-    if (m_categories->evaluate(*m_producers_manager))
+    if (m_categories->evaluate_post_analyzers(*m_producers_manager, *m_analyzers_manager))
         m_wrapper->fill();
     else
         m_wrapper->reset();
+
+    m_categories->reset();
 }
 
 

--- a/src/Framework.cc
+++ b/src/Framework.cc
@@ -33,7 +33,7 @@ ExTreeMaker::ExTreeMaker(const edm::ParameterSet& iConfig):
         m_wrapper.reset(new ROOT::TreeWrapper(tree));
 
         m_categories.reset(new CategoryManager(*m_wrapper));
-        m_producers_manager.reset(new ProducersManager(this));
+        m_producers_manager.reset(new ProducersManager(*this));
 
         // Load plugins
         if (!iConfig.existsAs<edm::ParameterSet>("producers")) {
@@ -172,7 +172,7 @@ void ExTreeMaker::endLuminosityBlock(const edm::LuminosityBlock& lumi, const edm
         analyzer->endLuminosityBlock(lumi, eventSetup);
 }
 
-Framework::Producer& ExTreeMaker::getProducer(const std::string& name) {
+const Framework::Producer& ExTreeMaker::getProducer(const std::string& name) const {
     const auto& producer = m_producers.find(name);
     if (producer == m_producers.end()) {
         std::stringstream details;
@@ -183,7 +183,7 @@ Framework::Producer& ExTreeMaker::getProducer(const std::string& name) {
     return *producer->second;
 }
 
-bool ExTreeMaker::producerExists(const std::string& name) {
+bool ExTreeMaker::producerExists(const std::string& name) const {
     const auto& producer = m_producers.find(name);
     return (producer != m_producers.end());
 }

--- a/src/Framework.cc
+++ b/src/Framework.cc
@@ -34,6 +34,7 @@ ExTreeMaker::ExTreeMaker(const edm::ParameterSet& iConfig):
 
         m_categories.reset(new CategoryManager(*m_wrapper));
         m_producers_manager.reset(new ProducersManager(*this));
+        m_analyzers_manager.reset(new AnalyzersManager(*this));
 
         // Load plugins
         if (!iConfig.existsAs<edm::ParameterSet>("producers")) {
@@ -87,6 +88,7 @@ ExTreeMaker::ExTreeMaker(const edm::ParameterSet& iConfig):
             analyzer->registerCategories(*m_categories);
 
             m_analyzers.push_back(analyzer);
+            m_analyzers_name.push_back(analyzerName);
         }
 
 }
@@ -186,6 +188,22 @@ const Framework::Producer& ExTreeMaker::getProducer(const std::string& name) con
 bool ExTreeMaker::producerExists(const std::string& name) const {
     const auto& producer = m_producers.find(name);
     return (producer != m_producers.end());
+}
+
+const Framework::Analyzer& ExTreeMaker::getAnalyzer(const std::string& name) const {
+    auto it = std::find(m_analyzers_name.begin(), m_analyzers_name.end(), name);
+    if (it == m_analyzers_name.end()) {
+        std::stringstream details;
+        details << "Analyzer '" << name << "' not found. Please load it first in the python configuration";
+        throw edm::Exception(edm::errors::NotFound, details.str());
+    }
+
+    return *m_analyzers[std::distance(m_analyzers_name.begin(), it)];
+}
+
+bool ExTreeMaker::analyzerExists(const std::string& name) const {
+    const auto& analyzer = std::find(m_analyzers_name.begin(), m_analyzers_name.end(), name);
+    return (analyzer != m_analyzers_name.end());
 }
 
 //define this as a plug-in

--- a/src/ProducersManager.cc
+++ b/src/ProducersManager.cc
@@ -1,17 +1,10 @@
 #include <cp3_llbb/Framework/interface/ProducersManager.h>
 
-#include <cp3_llbb/Framework/interface/Framework.h>
-#include <cp3_llbb/Framework/interface/Producer.h>
-
-ProducersManager::ProducersManager(ExTreeMaker* framework):
-    m_framework(framework) {
+ProducersManager::ProducersManager(const ProducerGetter& getter):
+    m_getter(getter) {
         // Empty
 }
 
-const Framework::Producer& ProducersManager::get(const std::string& name) const {
-    return m_framework->getProducer(name);
-}
-
 bool ProducersManager::exists(const std::string& name) const {
-    return m_framework->producerExists(name);
+    return m_getter.producerExists(name);
 }


### PR DESCRIPTION
@AlexandreMertens made some wise suggestions concerning categories management. This is an attempt to fix the situation.

Currently, the path followed by the code is:
 - Run producers
 - Run analyzers
 - Run categories
 - If an event belongs to no category, then drop it, otherwise, save everything

The issue here is you can't access categories information from the analyzer, because the code is ran after. An easy solution would be to invert the categories and analyzers step, but now you cannot longer access any data produced by the analyzers.

I opted for the following solution:
 - Run producers
 - Run categories pre-analyzers
 - If the event both now belongs into any categories, drop it and pass to the next event
 - Else, run analyzers
 - Run categories post-analyzers
 - If an event belongs to no category, then drop it, otherwise, save everything

A category now has two callbacks, ``bool event_in_category_pre_analyzers(const ProducersManager&)`` and ``bool event_in_category_post_analyzers(const ProducersManager&, const AnalyzersManager&)``. Now the tricky part:

 - For an event to belong to a category, both function has to return ``true``
 - ``bool event_in_category_pre_analyzers(const ProducersManager&)`` is called first, before the analyzers
 - ``bool event_in_category_post_analyzers(const ProducersManager&, const AnalyzersManager&)`` is only called if the pre-analyzers callback returns ``true``

Also, the ``evaluate_cuts`` is now splitted in ``evaluate_cuts_pre_analyers`` and ``evaluate_cuts_post_analyzers``.

If think this solution provides the flexibility we need. It still remains to add a way to get categories and cuts info from the analyzers, but it should be easy to do.

What do you think?

**Note**: This depends on #20 so it must be merged after. Please ignore first commit.