### PR TITLE
Store sum of event weight

### DIFF
--- a/interface/Analyzer.h
+++ b/interface/Analyzer.h
@@ -12,6 +12,7 @@
 
 #include <cp3_llbb/Framework/interface/Category.h>
 #include <cp3_llbb/Framework/interface/ProducersManager.h>
+#include <cp3_llbb/Framework/interface/MetadataManager.h>
 #include <cp3_llbb/TreeWrapper/interface/TreeWrapper.h>
 
 #include <Math/Vector4D.h>
@@ -35,8 +36,8 @@ namespace Framework {
 
             virtual void registerCategories(CategoryManager& manager) {}
 
-            virtual void beginJob() {}
-            virtual void endJob() {}
+            virtual void beginJob(MetadataManager&) {}
+            virtual void endJob(MetadataManager&) {}
 
             virtual void beginRun(const edm::Run&, const edm::EventSetup&) {}
             virtual void endRun(const edm::Run&, const edm::EventSetup&) {}

--- a/interface/EventProducer.h
+++ b/interface/EventProducer.h
@@ -26,6 +26,8 @@ class EventProducer: public Framework::Producer {
 
         virtual void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
+        virtual void endJob(MetadataManager&) override;
+
     private:
 
         // Tokens
@@ -33,6 +35,8 @@ class EventProducer: public Framework::Producer {
         edm::EDGetTokenT<std::vector<PileupSummaryInfo>> m_pu_info_token;
         edm::EDGetTokenT<GenEventInfoProduct> m_gen_info_token;
         edm::EDGetTokenT<LHEEventProduct> m_lhe_info_token;
+
+        float m_event_weight_sum = 0;
 
     public:
         // Tree members

--- a/interface/Framework.h
+++ b/interface/Framework.h
@@ -46,6 +46,9 @@ class ExTreeMaker: public edm::EDProducer {
         // Categories
         std::unique_ptr<CategoryManager> m_categories;
 
+        // Metadata
+        std::unique_ptr<MetadataManager> m_metadata;
+
         // Timing
         typedef std::chrono::system_clock clock;
         typedef std::chrono::milliseconds ms;

--- a/interface/MetadataManager.h
+++ b/interface/MetadataManager.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <TObject.h>
+#include <TFile.h>
+
+#include <vector>
+#include <memory>
+
+class MetadataManager {
+
+    public:
+        MetadataManager(TFile* file):
+            m_file(file) {
+                // Empty
+            }
+
+        // Specialized into .cc
+        template<typename T>
+            void add(const std::string& name, const T& value);
+
+    private:
+        TFile* m_file;
+        std::vector<std::shared_ptr<TObject>> m_trash;
+
+};

--- a/interface/Producer.h
+++ b/interface/Producer.h
@@ -11,6 +11,7 @@
 
 #include <cp3_llbb/TreeWrapper/interface/TreeWrapper.h>
 #include <cp3_llbb/Framework/interface/Tools.h>
+#include <cp3_llbb/Framework/interface/MetadataManager.h>
 
 #include <Math/Vector4D.h>
 
@@ -31,8 +32,8 @@ namespace Framework {
             virtual void produce(edm::Event&, const edm::EventSetup&) = 0;
             virtual void doConsumes(const edm::ParameterSet&, edm::ConsumesCollector&& collector) {}
 
-            virtual void beginJob() {}
-            virtual void endJob() {}
+            virtual void beginJob(MetadataManager&) {}
+            virtual void endJob(MetadataManager&) {}
 
             virtual void beginRun(const edm::Run&, const edm::EventSetup&) {}
             virtual void endRun(const edm::Run&, const edm::EventSetup&) {}

--- a/src/EventProducer.cc
+++ b/src/EventProducer.cc
@@ -45,6 +45,8 @@ void EventProducer::produce(edm::Event& event_, const edm::EventSetup& eventSetu
         }
     }
 
+    m_event_weight_sum += weight;
+
     edm::Handle<LHEEventProduct> lhe_info;
     if (event_.getByToken(m_lhe_info_token, lhe_info)) {
         lhe_originalXWGTUP = lhe_info->originalXWGTUP();
@@ -53,4 +55,9 @@ void EventProducer::produce(edm::Event& event_, const edm::EventSetup& eventSetu
             lhe_weights.push_back(std::make_pair(weight.id, weight.wgt));
         }
     }
+}
+
+void EventProducer::endJob(MetadataManager& metadata) {
+    metadata.add("event_weight_sum", m_event_weight_sum);
+    std::cout << "Sum of event weight: " << m_event_weight_sum << std::endl;
 }

--- a/src/Framework.cc
+++ b/src/Framework.cc
@@ -35,6 +35,8 @@ ExTreeMaker::ExTreeMaker(const edm::ParameterSet& iConfig):
         m_categories.reset(new CategoryManager(*m_wrapper));
         m_producers_manager.reset(new ProducersManager(this));
 
+        m_metadata.reset(new MetadataManager(m_output.get()));
+
         // Load plugins
         if (!iConfig.existsAs<edm::ParameterSet>("producers")) {
             throw new std::logic_error("No producers specified");
@@ -116,19 +118,19 @@ void ExTreeMaker::beginJob() {
     m_start_time = clock::now();
 
     for (auto& producer: m_producers)
-        producer.second->beginJob();
+        producer.second->beginJob(*m_metadata);
 
     for (auto& analyzer: m_analyzers)
-        analyzer->beginJob();
+        analyzer->beginJob(*m_metadata);
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
 void ExTreeMaker::endJob() {
     for (auto& producer: m_producers)
-        producer.second->endJob();
+        producer.second->endJob(*m_metadata);
 
     for (auto& analyzer: m_analyzers)
-        analyzer->endJob();
+        analyzer->endJob(*m_metadata);
 
     auto end_time = clock::now();
 

--- a/src/Framework.cc
+++ b/src/Framework.cc
@@ -126,6 +126,7 @@ void ExTreeMaker::beginJob() {
 
 // ------------ method called once each job just after ending the event loop  ------------
 void ExTreeMaker::endJob() {
+    std::cout << std::endl << "---" << std::endl;
     for (auto& producer: m_producers)
         producer.second->endJob(*m_metadata);
 

--- a/src/MetadataManager.cc
+++ b/src/MetadataManager.cc
@@ -1,0 +1,17 @@
+#include <cp3_llbb/Framework/interface/MetadataManager.h>
+
+#include <TParameter.h>
+
+template<>
+void MetadataManager::add(const std::string& name, const double& value) {
+    std::shared_ptr<TObject> v(new TParameter<double>(name.c_str(), value));
+    m_file->WriteTObject(v.get());
+    m_trash.push_back(v);
+}
+
+template<>
+void MetadataManager::add(const std::string& name, const float& value) {
+    std::shared_ptr<TObject> v(new TParameter<float>(name.c_str(), value));
+    m_file->WriteTObject(v.get());
+    m_trash.push_back(v);
+}


### PR DESCRIPTION
This PR adds a basic metadata manager allowing a producer to store metadata into the files. For now, only float and double are supported, but it's easy to extend it on demand for other (more complex) types.

This metadata manager is used to store the sum of event weight into the final file. This sum is also printed on stdout in case something needs to parse it.