### PR TITLE
Making the btag discriminators accessible from the producers

### DIFF
--- a/interface/JetsProducer.h
+++ b/interface/JetsProducer.h
@@ -35,6 +35,8 @@ class JetsProducer: public CandidatesProducer<pat::Jet>, public BTaggingScaleFac
         std::vector<float>& jecFactor = tree["jecFactor"].write<std::vector<float>>();
         std::vector<float>& puJetID = tree["puJetID"].write<std::vector<float>>();
         std::vector<float>& vtxMass = tree["vtxMass"].write<std::vector<float>>();
+
+        std::map<std::string, std::vector<float>> bTagDiscriminators;
 };
 
 #endif

--- a/plugins/TestAnalyzer.cc
+++ b/plugins/TestAnalyzer.cc
@@ -3,10 +3,15 @@
 #include <cp3_llbb/Framework/interface/GenParticlesProducer.h>
 #include <cp3_llbb/Framework/interface/JetsProducer.h>
 
+#include <iostream>
 
 void TestAnalyzer::analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager& producers) {
 
     const JetsProducer& jets = producers.get<JetsProducer>("jets");
+
+    for(size_t i = 0; i < jets.p4.size(); i++) {
+      std::cout << "Jet " << i << " Pt = " << jets.p4[i].Pt() << ", CSVv2 = " << jets.bTagDiscriminators.at("pfCombinedInclusiveSecondaryVertexV2BJetTags")[i] << std::endl;
+    }
 
 /*
     if (producers.exists("gen_particles")) {

--- a/src/JetsProducer.cc
+++ b/src/JetsProducer.cc
@@ -28,6 +28,9 @@ void JetsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
             std::vector<float>& branch = tree[btag_discri.first].write<std::vector<float>>();
             branch.push_back(btag_discri.second);
 
+            // store the discriminator values into the producer, for easy access by the analyzer
+            bTagDiscriminators[btag_discri.first].push_back(btag_discri.second);
+
             Algorithm algo = string_to_algorithm(btag_discri.first);
 
             if (algo != Algorithm::UNKNOWN && BTaggingScaleFactors::has_scale_factors(algo)) {


### PR DESCRIPTION
Add a variable to JetsProducer to make to btag discriminatros accessible from the producer.

(this is more of a suggestion open for discussion... I'd be happy to lear if there's a better way to do this. I've tried to avoid creating the branches in the loop, but rather in the constructor of the JetProducer, from the edm::parameter set passed to it, but that does't seem possible)