### PR TITLE
Dict vectors

### DIFF
--- a/interface/CandidatesProducer.h
+++ b/interface/CandidatesProducer.h
@@ -8,7 +8,7 @@
 template<typename ObjectType>
 class CandidatesProducer: public Framework::Producer {
     public:
-        CandidatesProducer(const std::string& name, const ROOT::TreeGroup& tree, const edm::ParameterSet& config):
+        CandidatesProducer(const std::string& name, ROOT::TreeGroup& tree, const edm::ParameterSet& config):
             Producer(name, tree, config),
             m_cut(config.getUntrackedParameter<std::string>("cut", "1"))
         {

--- a/interface/JetsProducer.h
+++ b/interface/JetsProducer.h
@@ -4,14 +4,17 @@
 #include <cp3_llbb/Framework/interface/CandidatesProducer.h>
 #include <cp3_llbb/Framework/interface/BTaggingScaleFactors.h>
 
+#include <boost/any.hpp>
 #include <DataFormats/PatCandidates/interface/Jet.h>
 
 class JetsProducer: public CandidatesProducer<pat::Jet>, public BTaggingScaleFactors {
     public:
-        JetsProducer(const std::string& name, const ROOT::TreeGroup& tree, const edm::ParameterSet& config):
+        JetsProducer(const std::string& name, ROOT::TreeGroup& tree, const edm::ParameterSet& config):
             CandidatesProducer(name, tree, config), BTaggingScaleFactors(const_cast<ROOT::TreeGroup&>(tree))
         {
             BTaggingScaleFactors::create_branches(config);
+
+            treeData["area"] = tree["area"].write<std::vector<float>>();
         }
 
         virtual ~JetsProducer() {}
@@ -29,7 +32,7 @@ class JetsProducer: public CandidatesProducer<pat::Jet>, public BTaggingScaleFac
 
     public:
         // Tree members
-        std::vector<float>& area = tree["area"].write<std::vector<float>>();
+        //std::vector<float>& area = tree["area"].write<std::vector<float>>();
         std::vector<int8_t>& partonFlavor = tree["partonFlavor"].write<std::vector<int8_t>>();
         std::vector<int8_t>& hadronFlavor = tree["hadronFlavor"].write<std::vector<int8_t>>();
         std::vector<float>& jecFactor = tree["jecFactor"].write<std::vector<float>>();

--- a/interface/JetsProducer.h
+++ b/interface/JetsProducer.h
@@ -35,6 +35,8 @@ class JetsProducer: public CandidatesProducer<pat::Jet>, public BTaggingScaleFac
         std::vector<float>& jecFactor = tree["jecFactor"].write<std::vector<float>>();
         std::vector<float>& puJetID = tree["puJetID"].write<std::vector<float>>();
         std::vector<float>& vtxMass = tree["vtxMass"].write<std::vector<float>>();
+
+        std::map<std::string, std::vector<float>> bTagDiscriminators;
 };
 
 #endif

--- a/interface/Producer.h
+++ b/interface/Producer.h
@@ -15,6 +15,8 @@
 
 #include <Math/Vector4D.h>
 
+#include <boost/any.hpp>
+
 #include <vector>
 #include <map>
 
@@ -24,7 +26,7 @@ namespace Framework {
 
     class Producer {
         public:
-            Producer(const std::string& name, const ROOT::TreeGroup& tree_, const edm::ParameterSet& config):
+            Producer(const std::string& name, ROOT::TreeGroup& tree_, const edm::ParameterSet& config):
                 m_name(name),
                 tree(tree_) {
                 }
@@ -41,9 +43,22 @@ namespace Framework {
             virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {}
             virtual void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {}
 
+            template<typename T> const T& get(int i) const { return boost::any_cast<const T&>(tree[variable]); }
+            
+            template<typename T> void push_back(std::string variable, T value){ 
+                std::vector<T> &var = boost::any_cast<std::vector<T>&>(tree[variable]);
+                var.push_back(value);
+                _data.push_back(std::make_pair(variable, value));
+            }
+
+            const boost::any& operator[](const int index) const { return data[index]; }
+            
         protected:
             std::string m_name;
             ROOT::TreeGroup tree;
+            
+            std::map<std::string, boost::any&> treeData;
+            std::vector<std::map<std::string, boost::any>> data;
     };
 
 }

--- a/plugins/TestAnalyzer.cc
+++ b/plugins/TestAnalyzer.cc
@@ -3,6 +3,8 @@
 #include <cp3_llbb/Framework/interface/GenParticlesProducer.h>
 #include <cp3_llbb/Framework/interface/JetsProducer.h>
 
+#include <boost/any.hpp>
+
 #include <iostream>
 
 void TestAnalyzer::analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager& producers) {
@@ -11,6 +13,8 @@ void TestAnalyzer::analyze(const edm::Event&, const edm::EventSetup&, const Prod
 
     for(size_t i = 0; i < jets.p4.size(); i++) {
       std::cout << "Jet " << i << " Pt = " << jets.p4[i].Pt() << ", CSVv2 = " << jets.bTagDiscriminators.at("pfCombinedInclusiveSecondaryVertexV2BJetTags")[i] << std::endl;
+      std::cout << "Jet " << i << " Pt = " << jets.p4[i].Pt() << ", area = " << jets.get<std::vector<float>>("area")[i] << std::endl;
+      std::cout << "Jet " << i << " Pt = " << jets.p4[i].Pt() << ", area = " << boost::any_cast<float>(jets[i]["area"]) << std::endl;
     }
 
 /*

--- a/plugins/TestAnalyzer.cc
+++ b/plugins/TestAnalyzer.cc
@@ -3,10 +3,15 @@
 #include <cp3_llbb/Framework/interface/GenParticlesProducer.h>
 #include <cp3_llbb/Framework/interface/JetsProducer.h>
 
+#include <iostream>
 
 void TestAnalyzer::analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager& producers) {
 
     const JetsProducer& jets = producers.get<JetsProducer>("jets");
+
+    for(size_t i = 0; i < jets.p4.size(); i++) {
+      std::cout << "Jet " << i << " Pt = " << jets.p4[i].Pt() << ", CSVv2 = " << jets.bTagDiscriminators.at("pfCombinedInclusiveSecondaryVertexV2BJetTags")[i] << std::endl;
+    }
 
 /*
     if (producers.exists("gen_particles")) {

--- a/src/JetsProducer.cc
+++ b/src/JetsProducer.cc
@@ -28,6 +28,9 @@ void JetsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
             std::vector<float>& branch = tree[btag_discri.first].write<std::vector<float>>();
             branch.push_back(btag_discri.second);
 
+            // store the discriminator values into the producer, for easy access by the analyzer
+            bTagDiscriminators[btag_discri.first].push_back(btag_discri.second);
+
             Algorithm algo = string_to_algorithm(btag_discri.first);
 
             if (algo != Algorithm::UNKNOWN && BTaggingScaleFactors::has_scale_factors(algo)) {

--- a/src/JetsProducer.cc
+++ b/src/JetsProducer.cc
@@ -13,7 +13,7 @@ void JetsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
         fill_candidate(jet, jet.genJet());
 
         jecFactor.push_back(jet.jecFactor(0));
-        area.push_back(jet.jetArea());
+        push_back("area", jet.jetArea());
         partonFlavor.push_back(jet.partonFlavour());
         hadronFlavor.push_back(jet.hadronFlavour());
 


### PR DESCRIPTION
NOT to be merged, only for discussion

This is an attempt to have a producer behave like a python list of dictionaries, i.e. a jetProducer behaves as a vector of "jets", where each jet behaves as a dictionary to access its variables: jetProducer[0]["area"] instead of jetProducer.area[0].

A lot is missing (it would be nice to be able to iterate over the jets, for instance) and there might be a more elegant way of doing it.

And of course, this only makes sense for producers of objects that are multiple inside the event (ie not MET, event, metadata).

It doesn't compile because I didn't bother to update all the producers, but even then it might not compile: I'm not sure my use of boost::any is correct (@blinkseb will surely be able to confirm)...