### PR TITLE
Make btagging discriminants accessible from analyzers

### DIFF
--- a/python/JetsProducer.py
+++ b/python/JetsProducer.py
@@ -5,6 +5,7 @@ default_configuration = cms.PSet(
         prefix = cms.string('jet_'),
         enable = cms.bool(True),
         parameters = cms.PSet(
+            btags = cms.untracked.vstring('pfCombinedInclusiveSecondaryVertexV2BJetTags', 'pfJetProbabilityBJetTags', 'pfCombinedMVABJetTags'),
             scale_factors = cms.untracked.PSet(
                 csv_loose = cms.untracked.PSet(
                     algorithm = cms.untracked.string('csv'),

--- a/src/JetsProducer.cc
+++ b/src/JetsProducer.cc
@@ -22,16 +22,14 @@ void JetsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
 
         vtxMass.push_back(jet.userFloat("vtxMass"));
 
-        auto& btag_discris = jet.getPairDiscri();
-        for (auto& btag_discri: btag_discris) {
-            // Get branch from tree
-            std::vector<float>& branch = tree[btag_discri.first].write<std::vector<float>>();
-            branch.push_back(btag_discri.second);
+        for (auto& it: m_btag_discriminators) {
 
-            Algorithm algo = string_to_algorithm(btag_discri.first);
+            float btag_discriminator = jet.bDiscriminator(it.first);
+            it.second->push_back(btag_discriminator);
 
+            Algorithm algo = string_to_algorithm(it.first);
             if (algo != Algorithm::UNKNOWN && BTaggingScaleFactors::has_scale_factors(algo)) {
-                BTaggingScaleFactors::store_scale_factors(algo, get_flavor(jet.hadronFlavour()), {static_cast<float>(fabs(jet.eta())), static_cast<float>(jet.pt()), btag_discri.second});
+                BTaggingScaleFactors::store_scale_factors(algo, get_flavor(jet.hadronFlavour()), {static_cast<float>(fabs(jet.eta())), static_cast<float>(jet.pt()), btag_discriminator});
             }
         }
     }


### PR DESCRIPTION
This is an attempt to fix the issue raised by #23. Only b-tagging discriminants requested by the user in the python configuration are considered. A branch per discriminant is still created, and one can access the b-tagging discriminant by using the function

```C++
float JetProducer::getBTagDiscriminant(size_t index, const std::string& name);
```