### PR TITLE
CMSSW release update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Common framework for all cp3-llbb analyses
 * The instructions are for the UCLouvain ingrid SLC6 cluster (to access SAMADhi)
 * You need the proper username and password to access SAMADhi :) If you don't know what this is about, ask around
 * The current state of the art mini-AOD documentation can be found [here](https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2015)
+* You will probably want to install as well [GridIn](https://github.com/cp3-llbb/GridIn) to run jobs on the grid, and one of the existing analyses ([TTAnalysis](https://github.com/cp3-llbb/TTAnalysis), [HHAnalysis](https://github.com/cp3-llbb/HHAnalysis))
 
 
 
@@ -14,15 +15,15 @@ Common framework for all cp3-llbb analyses
 source /nfs/soft/grid/ui_sl6/setup/grid-env.sh
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 export SCRAM_ARCH=slc6_amd64_gcc491
-cmsrel CMSSW_7_4_5
-cd CMSSW_7_4_5/src
+cmsrel CMSSW_7_4_10
+cd CMSSW_7_4_10/src
 cmsenv
 
 git cms-init
 cd ${CMSSW_BASE}/src 
 
-# Electron ID as from [June 28th 2015 EGamma hypernews](https://hypernews.cern.ch/HyperNews/CMS/get/egamma/1589.html)
-git cms-merge-topic ikrav:egm_id_74X_v2
+# Electron ID as from [EGamma twiki (as on September 1st 2015)](https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2)
+git cms-merge-topic ikrav:egm_id_747_v2
 
 # CP3-llbb framework itself
 git clone -o upstream git@github.com:blinkseb/TreeWrapper.git cp3_llbb/TreeWrapper
@@ -30,6 +31,10 @@ git clone -o upstream git@github.com:cp3-llbb/Framework.git cp3_llbb/Framework
 
 cd ${CMSSW_BASE}/src
 scram b -j 4
+
+cd ${CMSSW_BASE}/src/cp3_llbb/Framework
+source setup.sh
+cd ${CMSSW_BASE}/src
 ```
 
 ## Test run (command line)

--- a/python/ElectronsProducer.py
+++ b/python/ElectronsProducer.py
@@ -9,13 +9,17 @@ default_configuration = cms.PSet(
             ea_R03 = cms.untracked.FileInPath('RecoEgamma/ElectronIdentification/data/PHYS14/effAreaElectrons_cone03_pfNeuHadronsAndPhotons.txt'),
             ea_R04 = cms.untracked.FileInPath('cp3_llbb/Framework/data/effAreaElectrons_cone04_pfNeuHadronsAndPhotons.txt'),
             ids = cms.untracked.VInputTag(
-                'egmGsfElectronIDs:mvaEleID-PHYS14-PU20bx25-nonTrig-V1-wp80',
-                'egmGsfElectronIDs:mvaEleID-PHYS14-PU20bx25-nonTrig-V1-wp90',
-                'egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-loose',
-                'egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-medium',
-                'egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-tight',
-                'egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-veto',
-                'egmGsfElectronIDs:heepElectronID-HEEPV51'
+                'egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp80',
+                'egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp90',
+                'egmGsfElectronIDs:cutBasedElectronID-Spring15-50ns-V1-standalone-veto',
+                'egmGsfElectronIDs:cutBasedElectronID-Spring15-50ns-V1-standalone-loose',
+                'egmGsfElectronIDs:cutBasedElectronID-Spring15-50ns-V1-standalone-medium',
+                'egmGsfElectronIDs:cutBasedElectronID-Spring15-50ns-V1-standalone-tight',
+                'egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto',
+                'egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose',
+                'egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium',
+                'egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight',
+                'egmGsfElectronIDs:heepElectronID-HEEPV60'
                 ),
             scale_factors = cms.untracked.PSet(
                 id_veto = cms.untracked.FileInPath('cp3_llbb/Framework/data/ScaleFactors/Electron_sfVETO_id.json'),

--- a/test/TestConfiguration.py
+++ b/test/TestConfiguration.py
@@ -8,7 +8,8 @@ process.load("Configuration.EventContent.EventContent_cff")
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 
-process.GlobalTag.globaltag = "MCRUN2_74_V9"
+process.GlobalTag.globaltag = "MCRUN2_74_V9" # for Spring15 MC with 25ns asymptotic scenario
+#process.GlobalTag.globaltag = "74X_dataRun2_Prompt_v1" # for Run2015B/C (50/25ns) data taking
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(20))
 process.source = cms.Source("PoolSource")
@@ -22,7 +23,7 @@ from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 dataFormat = DataFormat.MiniAOD
 switchOnVIDElectronIdProducer(process, dataFormat)
 # define which IDs we want to produce
-my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.mvaElectronID_PHYS14_PU20bx25_nonTrig_V1_cff','RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_PHYS14_PU20bx25_V2_cff', 'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV51_cff']
+my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_50ns_V1_cff','RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff','RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff','RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff']
 #add them to the VID producer
 for idmod in my_id_modules:
     setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)


### PR DESCRIPTION
We need to update the CMSSW release to be able to run on Run2015C data. According to the [GlobalTag twiki](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions#Prompt_reconstruction_Global_Tag), CMSSW_7_4_10 should last long enough to also analyse Run2015D data

the other update is related to the electron ID recipe, as new instructions are available on the EGamma [twiki for MVA](https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2) and [twiki for Cut-based](https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2), and are recommended for use with Spring15 MC and 50/25ns data