### PR TITLE
Categories improvement

### DIFF
--- a/interface/Analyzer.h
+++ b/interface/Analyzer.h
@@ -32,7 +32,7 @@ namespace Framework {
                 tree(tree_) {
                 }
 
-            virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&) = 0;
+            virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const CategoryManager&) = 0;
             virtual void doConsumes(const edm::ParameterSet&, edm::ConsumesCollector&& collector) {}
 
             virtual void registerCategories(CategoryManager& manager) {}

--- a/interface/Category.h
+++ b/interface/Category.h
@@ -61,6 +61,24 @@ struct CategoryData {
     }
 };
 
+struct CategoryWrapper {
+    public:
+        CategoryWrapper(const CategoryData& d): data(d) {
+            // Empty
+        }
+
+        bool in_category() const {
+            return data.in_category_pre;
+        }
+
+        std::shared_ptr<CategoryMetadata> get_metadata() const {
+            return data.callback->get_metadata();
+        }
+
+    private:
+        const CategoryData& data;
+};
+
 class CategoryManager {
     friend class ExTreeMaker;
 
@@ -68,7 +86,38 @@ class CategoryManager {
         template<class T>
         void new_category(const std::string& name, const std::string& description) {
             std::unique_ptr<Category> category(new T());
-            m_categories.push_back(CategoryData(name, description, std::move(category), m_tree));
+            m_categories.emplace(name, CategoryData(name, description, std::move(category), m_tree));
+        }
+
+        bool in_category(const std::string& name) const {
+
+            const auto& category = m_categories.find(name);
+            if (category == m_categories.end()) {
+                std::stringstream details;
+                details << "Category '" << name << "' not found.";
+                throw edm::Exception(edm::errors::NotFound, details.str());
+            }
+
+            return category->second.in_category_pre;
+        }
+
+        const CategoryWrapper get(const std::string& name) const {
+
+            const auto& category = m_categories.find(name);
+            if (category == m_categories.end()) {
+                std::stringstream details;
+                details << "Category '" << name << "' not found.";
+                throw edm::Exception(edm::errors::NotFound, details.str());
+            }
+
+            return CategoryWrapper(category->second);
+        }
+
+    private:
+        CategoryManager(ROOT::TreeWrapper& tree):
+            m_tree(tree)
+        {
+            // Empty
         }
 
         bool evaluate_pre_analyzers(const ProducersManager& producers);
@@ -78,14 +127,8 @@ class CategoryManager {
 
         void print_summary();
 
-    private:
-        CategoryManager(ROOT::TreeWrapper& tree):
-            m_tree(tree)
-        {
-            // Empty
-        }
 
-        std::vector<CategoryData> m_categories;
+        std::unordered_map<std::string, CategoryData> m_categories;
         ROOT::TreeWrapper& m_tree;
 
         uint64_t processed_events = 0;

--- a/interface/Category.h
+++ b/interface/Category.h
@@ -13,6 +13,10 @@
 
 class CategoryManager;
 
+struct CategoryMetadata {
+    // Empty
+};
+
 class Category {
     public:
         virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const = 0;
@@ -22,6 +26,13 @@ class Category {
 
         virtual void evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const {};
         virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {};
+
+        virtual std::shared_ptr<CategoryMetadata> get_metadata() final {
+            return metadata;
+        };
+
+    protected:
+        std::shared_ptr<CategoryMetadata> metadata;
 };
 
 struct CategoryData {

--- a/interface/TestAnalyzer.h
+++ b/interface/TestAnalyzer.h
@@ -38,7 +38,7 @@ class TestAnalyzer: public Framework::Analyzer {
 
         }
 
-        virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&) override;
+        virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const CategoryManager&) override;
 
         virtual void registerCategories(CategoryManager& manager) {
             manager.new_category<TwoMuonsCategory>("two_muons", "At least two muons category");

--- a/plugins/TestAnalyzer.cc
+++ b/plugins/TestAnalyzer.cc
@@ -4,7 +4,7 @@
 #include <cp3_llbb/Framework/interface/JetsProducer.h>
 
 
-void TestAnalyzer::analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager& producers) {
+void TestAnalyzer::analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager& producers, const CategoryManager& categories) {
 
     const JetsProducer& jets = producers.get<JetsProducer>("jets");
 
@@ -22,4 +22,13 @@ void TestAnalyzer::analyze(const edm::Event&, const edm::EventSetup&, const Prod
         std::cout << "Jet pt: " << p4.P() << std::endl;
     }
 */
+
+    // Test if event is in category
+    bool in_category = categories.in_category("two_muons");
+    if (in_category) {
+
+    }
+
+    // Get category metadata
+    std::shared_ptr<CategoryMetadata> metadata = categories.get("two_muons").get_metadata();
 }

--- a/src/Category.cc
+++ b/src/Category.cc
@@ -7,10 +7,10 @@ bool CategoryManager::evaluate_pre_analyzers(const ProducersManager& producers) 
     bool ret = m_categories.empty();
 
     for (auto& category: m_categories) {
-        if (category.callback->event_in_category_pre_analyzers(producers)) {
+        if (category.second.callback->event_in_category_pre_analyzers(producers)) {
             ret = true;
-            category.in_category_pre = true;
-            category.callback->evaluate_cuts_pre_analyzers(category.cut_manager, producers);
+            category.second.in_category_pre = true;
+            category.second.callback->evaluate_cuts_pre_analyzers(category.second.cut_manager, producers);
         }
     }
 
@@ -21,12 +21,12 @@ bool CategoryManager::evaluate_post_analyzers(const ProducersManager& producers,
     bool ret = m_categories.empty();
 
     for (auto& category: m_categories) {
-        if (category.in_category_pre && category.callback->event_in_category_post_analyzers(producers, analyzers)) {
+        if (category.second.in_category_pre && category.second.callback->event_in_category_post_analyzers(producers, analyzers)) {
             ret = true;
-            category.in_category_post = true;
-            category.in_category = true;
-            category.events++;
-            category.callback->evaluate_cuts_post_analyzers(category.cut_manager, producers, analyzers);
+            category.second.in_category_post = true;
+            category.second.in_category = true;
+            category.second.events++;
+            category.second.callback->evaluate_cuts_post_analyzers(category.second.cut_manager, producers, analyzers);
         }
     }
 
@@ -39,8 +39,8 @@ bool CategoryManager::evaluate_post_analyzers(const ProducersManager& producers,
 
 void CategoryManager::reset() {
     for (auto& category: m_categories) {
-        category.in_category_pre = false;
-        category.in_category_post = false;
+        category.second.in_category_pre = false;
+        category.second.in_category_post = false;
     }
 }
 
@@ -54,6 +54,6 @@ void CategoryManager::print_summary() {
     printf("%-60s %20s\n", "Category", "# events");
     printf("---------------------------------------------------------------------------------\n");
     for (auto& category: m_categories)
-        printf("%-60s %20" PRIu64 "\n", category.name.c_str(), category.events);
+        printf("%-60s %20" PRIu64 "\n", category.second.name.c_str(), category.second.events);
 }
 

--- a/src/Framework.cc
+++ b/src/Framework.cc
@@ -112,7 +112,7 @@ void ExTreeMaker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     }
 
     for (auto& analyzer: m_analyzers)
-        analyzer->analyze(iEvent, iSetup, *m_producers_manager);
+        analyzer->analyze(iEvent, iSetup, *m_producers_manager, *m_categories);
 
     if (m_categories->evaluate_post_analyzers(*m_producers_manager, *m_analyzers_manager))
         m_wrapper->fill();


### PR DESCRIPTION
This PR improves a bit the categories:

 - A ``metadata`` field is added to the ``Category`` class. This let the user stores what he wants inside. It's useful for example to store information about combinatorics, like the index of the leptons chosen for example. These metedata are accessible from the analyzer.

 - A new argument is added to the ``analyze`` function, ``const CategoryManager&``. It provides access to the categories and let the user know if the event is inside a given category. Use this interface to access the metadata of a category.