### PR TITLE
MET Filters

### DIFF
--- a/interface/Filter.h
+++ b/interface/Filter.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <FWCore/PluginManager/interface/PluginFactory.h>
+#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include <FWCore/Framework/interface/Event.h>
+#include <FWCore/Framework/interface/Run.h>
+#include <FWCore/Framework/interface/LuminosityBlock.h>
+#include <FWCore/Framework/interface/EventSetup.h>
+#include <FWCore/Framework/interface/ConsumesCollector.h>
+#include <FWCore/Utilities/interface/InputTag.h>
+
+#include <cp3_llbb/Framework/interface/Tools.h>
+#include <cp3_llbb/Framework/interface/MetadataManager.h>
+
+#include <Math/Vector4D.h>
+
+#include <vector>
+#include <map>
+
+namespace Framework {
+
+    class Filter {
+        public:
+            Filter(const std::string& name, const edm::ParameterSet& config):
+                m_name(name) {
+                }
+
+            virtual bool filter(edm::Event&, const edm::EventSetup&) = 0;
+            virtual void doConsumes(const edm::ParameterSet&, edm::ConsumesCollector&& collector) {}
+
+            virtual void beginJob(MetadataManager&) {}
+            virtual void endJob(MetadataManager&) {}
+
+            virtual void beginRun(const edm::Run&, const edm::EventSetup&) {}
+            virtual void endRun(const edm::Run&, const edm::EventSetup&) {}
+
+            virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {}
+            virtual void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {}
+
+        protected:
+            std::string m_name;
+    };
+
+}
+
+typedef edmplugin::PluginFactory<Framework::Filter* (const std::string&, const edm::ParameterSet&)> ExTreeMakerFilterFactory;

--- a/interface/Framework.h
+++ b/interface/Framework.h
@@ -11,6 +11,7 @@
 
 #include "cp3_llbb/Framework/interface/Analyzer.h"
 #include "cp3_llbb/Framework/interface/Producer.h"
+#include "cp3_llbb/Framework/interface/Filter.h"
 #include "cp3_llbb/Framework/interface/Category.h"
 #include "cp3_llbb/Framework/interface/ProducerGetter.h"
 #include "cp3_llbb/Framework/interface/ProducersManager.h"
@@ -50,6 +51,7 @@ class ExTreeMaker: public edm::EDProducer, ProducerGetter, AnalyzerGetter {
         std::unique_ptr<TFile> m_output;
         std::unique_ptr<ROOT::TreeWrapper> m_wrapper;
         std::unordered_map<std::string, std::shared_ptr<Framework::Producer>> m_producers;
+        std::unordered_map<std::string, std::shared_ptr<Framework::Filter>> m_filters;
 
 
         // Order is important, we can't use a map here

--- a/interface/METFilter.h
+++ b/interface/METFilter.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cp3_llbb/Framework/interface/Filter.h>
+#include <DataFormats/Common/interface/TriggerResults.h>
+
+class METFilter: public Framework::Filter {
+    public:
+        METFilter(const std::string& name, const edm::ParameterSet& config):
+            Filter(name, config)
+        {
+            m_flags = config.getUntrackedParameter<std::vector<std::string>>("flags");
+        }
+
+        virtual ~METFilter() {}
+
+        virtual void doConsumes(const edm::ParameterSet& config, edm::ConsumesCollector&& collector) override {
+            m_met_filters_token = collector.consumes<edm::TriggerResults>(config.getUntrackedParameter<edm::InputTag>("filters", edm::InputTag("TriggerResults", "", "PAT")));
+        }
+
+        virtual bool filter(edm::Event& event, const edm::EventSetup& eventSetup) override;
+
+    private:
+
+        // Tokens
+        edm::EDGetTokenT<edm::TriggerResults> m_met_filters_token;
+
+        std::vector<std::string> m_flags;
+};

--- a/python/METFilter.py
+++ b/python/METFilter.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+default_configuration = cms.PSet(
+        type = cms.string('met'),
+        enable = cms.bool(True),
+        parameters = cms.PSet(
+            # Note: HBHE noise filter is ran on-the-fly before the framework
+            flags = cms.untracked.vstring('Flag_CSCTightHaloFilter', 'Flag_goodVertices', 'Flag_eeBadScFilter')
+            )
+        )
+

--- a/src/FilterPluginFactory.cc
+++ b/src/FilterPluginFactory.cc
@@ -1,0 +1,4 @@
+#include <cp3_llbb/Framework/interface/Filter.h>
+
+EDM_REGISTER_PLUGINFACTORY(ExTreeMakerFilterFactory, "ExTreeMakerFilterFactory");
+

--- a/src/Filters.cc
+++ b/src/Filters.cc
@@ -1,0 +1,6 @@
+#include <FWCore/PluginManager/interface/PluginFactory.h>
+
+#include <cp3_llbb/Framework/interface/METFilter.h>
+
+DEFINE_EDM_PLUGIN(ExTreeMakerFilterFactory, METFilter, "met");
+

--- a/src/METFilter.cc
+++ b/src/METFilter.cc
@@ -1,0 +1,22 @@
+#include <cp3_llbb/Framework/interface/METFilter.h>
+
+#include <FWCore/Common/interface/TriggerNames.h>
+
+bool METFilter::filter(edm::Event& event, const edm::EventSetup& eventSetup) {
+    edm::Handle<edm::TriggerResults> filters;
+    event.getByToken(m_met_filters_token, filters);
+
+    const edm::TriggerNames& triggerNames = event.triggerNames(*filters);
+
+    for (size_t i = 0 ; i < filters->size(); i++) {
+        std::string triggerName = triggerNames.triggerName(i);
+        if (std::find(m_flags.begin(), m_flags.end(), triggerName) != m_flags.end()) {
+            if (!filters->accept(i))
+                return false;
+        } else {
+            continue;
+        }
+    }
+
+    return true;
+}

--- a/test/TestConfiguration.py
+++ b/test/TestConfiguration.py
@@ -84,7 +84,18 @@ process.framework = cms.EDProducer("ExTreeMaker",
 
 process.framework.producers.jets.parameters.cut = cms.untracked.string("pt > 10")
 
+# MET Filters
+
+process.load('CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi')
+process.filterOnHBHENoiseFilter = cms.EDFilter('BooleanFlagFilter',
+   inputLabel = cms.InputTag('HBHENoiseFilterResultProducer', 'HBHENoiseFilterResultRun1'), # this is for the 50ns
+#   inputLabel = cms.InputTag('HBHENoiseFilterResultProducer', 'HBHENoiseFilterResulttRun2Loose'), # this is for the 25ns
+#   inputLabel = cms.InputTag('HBHENoiseFilterResultProducer', 'HBHENoiseFilterResulttRun2Tight'), # this is for the 25ns
+   reverseDecision = cms.bool(False)
+)
+
 process.p = cms.Path(
+        process.filterOnHBHENoiseFilter *
         process.egmGsfElectronIDSequence *
         process.framework
         )

--- a/test/TestConfiguration.py
+++ b/test/TestConfiguration.py
@@ -44,8 +44,15 @@ from cp3_llbb.Framework import MuonsProducer
 from cp3_llbb.Framework import ElectronsProducer
 from cp3_llbb.Framework import VerticesProducer
 
+# Filters
+from cp3_llbb.Framework import METFilter
+
 process.framework = cms.EDProducer("ExTreeMaker",
         output = cms.string('output_mc.root'),
+
+        filters = cms.PSet(
+            met = METFilter.default_configuration
+            ),
 
         producers = cms.PSet(
 


### PR DESCRIPTION
This PR introduces support of filters inside the framework.

Filters are simple modules which do not store anything inside the output tree. They only decides if the framework should keep or drop the current event.

A filter is introduced, ``METFilter`` which impose that required MET filters are on for the event (see https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#MiniAOD)