### PR TITLE
Adding dilepton categories / analyzer

### DIFF
--- a/interface/DileptonAnalyzer.h
+++ b/interface/DileptonAnalyzer.h
@@ -1,0 +1,32 @@
+#ifndef DILEPTONANALYZER_H
+#define DILEPTONANALYZER_H
+
+#include <cp3_llbb/Framework/interface/Analyzer.h>
+#include <cp3_llbb/Framework/interface/Category.h>
+
+class DileptonAnalyzer: public Framework::Analyzer {
+    public:
+        HHAnalyzer(const std::string& name, const ROOT::TreeGroup& tree_, const edm::ParameterSet& config):
+            Analyzer(name, tree_, config) {
+
+        }
+
+        virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const AnalyzersManager& analyzers) override;
+
+        virtual void registerCategories(CategoryManager& manager) override;
+
+        BRANCH(dimuons, std::vector<LorentzVector>);
+        BRANCH(dielectrons, std::vector<LorentzVector>);
+        BRANCH(dileptons_emu, std::vector<LorentzVector>);
+        BRANCH(dileptons_mue, std::vector<LorentzVector>);
+        BRANCH(dimuons_indices, std::vector<std::pair<unsigned int,unsigned int>>);
+        BRANCH(dielectrons_indices, std::vector<std::pair<unsigned int,unsigned int>>);
+        BRANCH(dileptons_emu_indices, std::vector<std::pair<unsigned int,unsigned int>>);
+        BRANCH(dileptons_mue_indices, std::vector<std::pair<unsigned int,unsigned int>>);
+
+    private:
+        // empty
+};
+
+
+#endif

--- a/interface/DileptonAnalyzer.h
+++ b/interface/DileptonAnalyzer.h
@@ -15,14 +15,14 @@ class DileptonAnalyzer: public Framework::Analyzer {
 
         virtual void registerCategories(CategoryManager& manager) override;
 
-        BRANCH(dimuons, std::vector<LorentzVector>);
-        BRANCH(dielectrons, std::vector<LorentzVector>);
-        BRANCH(dileptons_emu, std::vector<LorentzVector>);
-        BRANCH(dileptons_mue, std::vector<LorentzVector>);
-        BRANCH(dimuons_indices, std::vector<std::pair<unsigned int,unsigned int>>);
-        BRANCH(dielectrons_indices, std::vector<std::pair<unsigned int,unsigned int>>);
-        BRANCH(dileptons_emu_indices, std::vector<std::pair<unsigned int,unsigned int>>);
-        BRANCH(dileptons_mue_indices, std::vector<std::pair<unsigned int,unsigned int>>);
+        BRANCH(dileptons_mumu, std::vector<LorentzVector>);
+        BRANCH(dileptons_elel, std::vector<LorentzVector>);
+        BRANCH(dileptons_elmu, std::vector<LorentzVector>);
+        BRANCH(dileptons_muel, std::vector<LorentzVector>);
+        BRANCH(dileptons_mumu_indices, std::vector<std::pair<unsigned int,unsigned int>>);
+        BRANCH(dileptons_elel_indices, std::vector<std::pair<unsigned int,unsigned int>>);
+        BRANCH(dileptons_elmu_indices, std::vector<std::pair<unsigned int,unsigned int>>);
+        BRANCH(dileptons_muel_indices, std::vector<std::pair<unsigned int,unsigned int>>);
 
     private:
         // empty

--- a/interface/DileptonAnalyzer.h
+++ b/interface/DileptonAnalyzer.h
@@ -6,12 +6,12 @@
 
 class DileptonAnalyzer: public Framework::Analyzer {
     public:
-        HHAnalyzer(const std::string& name, const ROOT::TreeGroup& tree_, const edm::ParameterSet& config):
+        DileptonAnalyzer(const std::string& name, const ROOT::TreeGroup& tree_, const edm::ParameterSet& config):
             Analyzer(name, tree_, config) {
 
         }
 
-        virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const AnalyzersManager& analyzers) override;
+        virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const CategoryManager&) override;
 
         virtual void registerCategories(CategoryManager& manager) override;
 

--- a/interface/DileptonCategories.h
+++ b/interface/DileptonCategories.h
@@ -7,7 +7,6 @@ class MuMuCategory: public Category {
     virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
     virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
     virtual void register_cuts(CutManager& manager) override;
-    virtual void evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const override;
     virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
 };
 
@@ -15,7 +14,6 @@ class MuElCategory: public Category {
     virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
     virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
     virtual void register_cuts(CutManager& manager) override;
-    virtual void evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const override;
     virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
 };
 
@@ -23,7 +21,6 @@ class ElMuCategory: public Category {
     virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
     virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
     virtual void register_cuts(CutManager& manager) override;
-    virtual void evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const override;
     virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
 };
 
@@ -31,7 +28,6 @@ class ElElCategory: public Category {
     virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
     virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
     virtual void register_cuts(CutManager& manager) override;
-    virtual void evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const override;
     virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
 };
 

--- a/interface/DileptonCategories.h
+++ b/interface/DileptonCategories.h
@@ -1,6 +1,8 @@
 #ifndef DILEPTONCATEGORIES_H
 #define DILEPTONCATEGORIES_H
 
+#include <cp3_llbb/Framework/interface/Category.h>
+
 class MuMuCategory: public Category {
     virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
     virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;

--- a/interface/DileptonCategories.h
+++ b/interface/DileptonCategories.h
@@ -1,0 +1,36 @@
+#ifndef DILEPTONCATEGORIES_H
+#define DILEPTONCATEGORIES_H
+
+class MuMuCategory: public Category {
+    virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
+    virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
+    virtual void register_cuts(CutManager& manager) override;
+    virtual void evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const override;
+    virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
+};
+
+class MuElCategory: public Category {
+    virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
+    virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
+    virtual void register_cuts(CutManager& manager) override;
+    virtual void evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const override;
+    virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
+};
+
+class ElMuCategory: public Category {
+    virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
+    virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
+    virtual void register_cuts(CutManager& manager) override;
+    virtual void evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const override;
+    virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
+};
+
+class ElElCategory: public Category {
+    virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
+    virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
+    virtual void register_cuts(CutManager& manager) override;
+    virtual void evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const override;
+    virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
+};
+
+#endif

--- a/plugins/Analyzers.cc
+++ b/plugins/Analyzers.cc
@@ -1,5 +1,7 @@
 #include <FWCore/PluginManager/interface/PluginFactory.h>
 
+#include <cp3_llbb/Framework/interface/DileptonAnalyzer.h>
 #include <cp3_llbb/Framework/interface/TestAnalyzer.h>
 
+DEFINE_EDM_PLUGIN(ExTreeMakerAnalyzerFactory, DileptonAnalyzer, "dilepton_analyzer");
 DEFINE_EDM_PLUGIN(ExTreeMakerAnalyzerFactory, TestAnalyzer, "test_analyzer");

--- a/plugins/DileptonAnalyzer.cc
+++ b/plugins/DileptonAnalyzer.cc
@@ -5,7 +5,15 @@
 #include <cp3_llbb/Framework/interface/ElectronsProducer.h>
 #include <cp3_llbb/Framework/interface/MuonsProducer.h>
 
-void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const ProducersManager& producers, const AnalyzersManager& analyzers) {
+
+void DileptonAnalyzer::registerCategories(CategoryManager& manager) {
+    manager.new_category<MuMuCategory>("mumu", "Category with leading leptons as two muons");
+    manager.new_category<ElElCategory>("elel", "Category with leading leptons as two electrons");
+    manager.new_category<MuElCategory>("muel", "Category with leading leptons as muon, electron");
+    manager.new_category<ElMuCategory>("elmu", "Category with leading leptons as electron, muon");
+}
+
+void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const ProducersManager& producers, const CategoryManager& categories) {
 
 // ***** ***** *****
 // Get all dilepton objects out of the event

--- a/plugins/DileptonAnalyzer.cc
+++ b/plugins/DileptonAnalyzer.cc
@@ -1,0 +1,89 @@
+#include <cp3_llbb/Framework/interface/DileptonAnalyzer.h>
+#include <cp3_llbb/Framework/interface/DileptonCategories.h>
+
+#include <cp3_llbb/Framework/interface/LeptonsProducer.h>
+#include <cp3_llbb/Framework/interface/ElectronsProducer.h>
+#include <cp3_llbb/Framework/interface/MuonsProducer.h>
+
+void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const ProducersManager& producers, const AnalyzersManager& analyzers) {
+
+// ***** ***** *****
+// Get all dilepton objects out of the event
+// ***** ***** *****
+    const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
+    const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
+
+    // Dimuons
+    for( unsigned int imuon = 0 ; imuon < muons.p4.size() ; imuon++ )
+    {
+        if(muons.isLoose[imuon])
+        {
+            for( unsigned int jmuon = imuon+1 ; jmuon < muons.p4.size() ; jmuon++ )
+            {
+                if( muons.isLoose[jmuon] && muons.charge[imuon] * muons.charge[jmuon] < 0 )
+                {
+                    LorentzVector dimuon = muons.p4[imuon] + muons.p4[jmuon];
+                    dimuons.push_back(dimuon);
+                    dimuons_indices.push_back(std::make_pair(imuon, jmuon));
+                }
+            }
+        }
+    }
+
+    // Dielectrons
+    for( unsigned int ielectron = 0 ; ielectron < electrons.p4.size() ; ielectron++ )
+    {
+        if(electrons.ids[ielectron]["cutBasedElectronID-Spring15-50ns-V1-standalone-loose"])
+        {
+            for( unsigned int jelectron = ielectron+1 ; jelectron < electrons.p4.size() ; jelectron++ )
+            {
+                if( electrons.ids[jelectron]["cutBasedElectronID-Spring15-50ns-V1-standalone-loose"] && electrons.charge[ielectron] * electrons.charge[jelectron] < 0 )
+                {
+                    LorentzVector dielectron = electrons.p4[ielectron] + electrons.p4[jelectron];
+                    dielectrons.push_back(dielectron);
+                    dielectrons_indices.push_back(std::make_pair(ielectron, jelectron));
+                }
+            }
+        }
+    }
+
+    //Dilepton electron-muon
+    for( unsigned int ielectron = 0 ; ielectron < electrons.p4.size() ; ielectron++ )
+    {
+        if(electrons.ids[ielectron]["cutBasedElectronID-Spring15-50ns-V1-standalone-loose"])
+        {
+            for( unsigned int jmuon = 0 ; jmuon < muons.p4.size() ; jmuon++ )
+            {
+                if( muons.p4[jmuon].pt() < electrons.p4[ielectron].pt() &&
+                    muons.isLoose[jmuon] &&
+                    electrons.charge[ielectron] * muons.charge[jmuon] < 0 )
+                {
+                    LorentzVector dilepton = electrons.p4[ielectron] + muons.p4[jmuon];
+                    dileptons_emu.push_back(dilepton);
+                    dileptons_emu_indices.push_back(std::make_pair(ielectron, jmuon));
+                }
+            }
+        }
+    }
+
+    //Dilepton muon-electron
+    for( unsigned int imuon = 0 ; imuon < muons.p4.size() ; imuon++ )
+    {
+        if(muons.isLoose[imuon])
+        {
+            for( unsigned int jelectron = 0 ; jelectron < electrons.p4.size() ; jelectron++ )
+            {
+                if( electrons.p4[jelectron].pt() < muons.p4[imuon].pt() &&
+                    electrons.ids[jelectron]["cutBasedElectronID-Spring15-50ns-V1-standalone-loose"] &&
+                    muons.charge[imuon] * electrons.charge[jelectron] < 0 )
+                {
+                    LorentzVector dilepton = muons.p4[imuon] + electrons.p4[jelectron];
+                    dileptons_mue.push_back(dilepton);
+                    dileptons_mue_indices.push_back(std::make_pair(imuon, jelectron));
+                }
+            }
+        }
+    }
+
+}
+

--- a/plugins/DileptonAnalyzer.cc
+++ b/plugins/DileptonAnalyzer.cc
@@ -22,7 +22,7 @@ void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, 
     const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
 
     // Dimuons
-    for( unsigned int imuon = 0 ; imuon < muons.p4.size() ; imuon++ )
+    for( unsigned int imuon = 0 ; imuon < muons.p4.size()-1 ; imuon++ )
     {
         if(muons.isLoose[imuon])
         {
@@ -39,7 +39,7 @@ void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, 
     }
 
     // Dielectrons
-    for( unsigned int ielectron = 0 ; ielectron < electrons.p4.size() ; ielectron++ )
+    for( unsigned int ielectron = 0 ; ielectron < electrons.p4.size()-1 ; ielectron++ )
     {
         if(electrons.ids[ielectron]["cutBasedElectronID-Spring15-50ns-V1-standalone-loose"])
         {

--- a/plugins/DileptonAnalyzer.cc
+++ b/plugins/DileptonAnalyzer.cc
@@ -31,8 +31,8 @@ void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, 
                 if( muons.isLoose[jmuon] && muons.charge[imuon] * muons.charge[jmuon] < 0 )
                 {
                     LorentzVector dimuon = muons.p4[imuon] + muons.p4[jmuon];
-                    dimuons.push_back(dimuon);
-                    dimuons_indices.push_back(std::make_pair(imuon, jmuon));
+                    dileptons_mumu.push_back(dimuon);
+                    dileptons_mumu_indices.push_back(std::make_pair(imuon, jmuon));
                 }
             }
         }
@@ -48,8 +48,8 @@ void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, 
                 if( electrons.ids[jelectron]["cutBasedElectronID-Spring15-50ns-V1-standalone-loose"] && electrons.charge[ielectron] * electrons.charge[jelectron] < 0 )
                 {
                     LorentzVector dielectron = electrons.p4[ielectron] + electrons.p4[jelectron];
-                    dielectrons.push_back(dielectron);
-                    dielectrons_indices.push_back(std::make_pair(ielectron, jelectron));
+                    dileptons_elel.push_back(dielectron);
+                    dileptons_elel_indices.push_back(std::make_pair(ielectron, jelectron));
                 }
             }
         }
@@ -67,8 +67,8 @@ void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, 
                     electrons.charge[ielectron] * muons.charge[jmuon] < 0 )
                 {
                     LorentzVector dilepton = electrons.p4[ielectron] + muons.p4[jmuon];
-                    dileptons_emu.push_back(dilepton);
-                    dileptons_emu_indices.push_back(std::make_pair(ielectron, jmuon));
+                    dileptons_elmu.push_back(dilepton);
+                    dileptons_elmu_indices.push_back(std::make_pair(ielectron, jmuon));
                 }
             }
         }
@@ -86,8 +86,8 @@ void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, 
                     muons.charge[imuon] * electrons.charge[jelectron] < 0 )
                 {
                     LorentzVector dilepton = muons.p4[imuon] + electrons.p4[jelectron];
-                    dileptons_mue.push_back(dilepton);
-                    dileptons_mue_indices.push_back(std::make_pair(imuon, jelectron));
+                    dileptons_muel.push_back(dilepton);
+                    dileptons_muel_indices.push_back(std::make_pair(imuon, jelectron));
                 }
             }
         }

--- a/plugins/DileptonCategories.cc
+++ b/plugins/DileptonCategories.cc
@@ -30,8 +30,12 @@ void MuMuCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const Produc
 
 void MuMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
-    if( dilepton_analyzer.dileptons_mumu[0].M() > 20. )
-        manager.pass_cut("ll_mass");
+    for(unsigned int idilepton = 0; idilepton < dilepton_analyzer.dileptons_mumu.size(); idilepton++)
+        if( dilepton_analyzer.dileptons_mumu[idilepton].M() > 20. )
+        {
+            manager.pass_cut("ll_mass");
+            break;
+        }
 }
 
 // ***** ***** *****
@@ -60,8 +64,12 @@ void MuElCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const Produc
 
 void MuElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
-    if( dilepton_analyzer.dileptons_muel[0].M() > 20. )
-        manager.pass_cut("ll_mass");
+    for(unsigned int idilepton = 0; idilepton < dilepton_analyzer.dileptons_muel.size(); idilepton++)
+        if( dilepton_analyzer.dileptons_muel[idilepton].M() > 20. )
+        {
+            manager.pass_cut("ll_mass");
+            break;
+        }
 }
 
 // ***** ***** *****
@@ -91,8 +99,12 @@ void ElMuCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const Produc
 
 void ElMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
-    if( dilepton_analyzer.dileptons_elmu[0].M() > 20. )
-        manager.pass_cut("ll_mass");
+    for(unsigned int idilepton = 0; idilepton < dilepton_analyzer.dileptons_elmu.size(); idilepton++)
+        if( dilepton_analyzer.dileptons_elmu[idilepton].M() > 20. )
+        {
+            manager.pass_cut("ll_mass");
+            break;
+        }
 }
 
 // ***** ***** *****
@@ -120,7 +132,11 @@ void ElElCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const Produc
 
 void ElElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
-    if( dilepton_analyzer.dileptons_elel[0].M() > 20. )
-        manager.pass_cut("ll_mass");
+    for(unsigned int idilepton = 0; idilepton < dilepton_analyzer.dileptons_elel.size(); idilepton++)
+        if( dilepton_analyzer.dileptons_elel[idilepton].M() > 20. )
+        {
+            manager.pass_cut("ll_mass");
+            break;
+        }
 }
 

--- a/plugins/DileptonCategories.cc
+++ b/plugins/DileptonCategories.cc
@@ -14,8 +14,8 @@ bool MuMuCategory::event_in_category_pre_analyzers(const ProducersManager& produ
 };
 
 bool MuMuCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
-    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
-    return hh_analyzer.dimuons.size() > 0;
+    const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
+    return dilepton_analyzer.dimuons.size() > 0;
 };
 
 void MuMuCategory::register_cuts(CutManager& manager) {
@@ -29,8 +29,8 @@ void MuMuCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const Produc
 }
 
 void MuMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
-    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
-    if( hh_analyzer.dimuons[0].M() > 20. )
+    const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
+    if( dilepton_analyzer.dimuons[0].M() > 20. )
         manager.pass_cut("ll_mass");
 }
 
@@ -44,8 +44,8 @@ bool MuElCategory::event_in_category_pre_analyzers(const ProducersManager& produ
 };
 
 bool MuElCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
-    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
-    return hh_analyzer.dileptons_mue.size() > 0;
+    const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
+    return dilepton_analyzer.dileptons_mue.size() > 0;
 };
 
 void MuElCategory::register_cuts(CutManager& manager) {
@@ -59,8 +59,8 @@ void MuElCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const Produc
 }
 
 void MuElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
-    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
-    if( hh_analyzer.dileptons_mue[0].M() > 20. )
+    const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
+    if( dilepton_analyzer.dileptons_mue[0].M() > 20. )
         manager.pass_cut("ll_mass");
 }
 
@@ -74,8 +74,8 @@ bool ElMuCategory::event_in_category_pre_analyzers(const ProducersManager& produ
 };
 
 bool ElMuCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
-    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
-    return hh_analyzer.dileptons_emu.size() > 0;
+    const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
+    return dilepton_analyzer.dileptons_emu.size() > 0;
 };
 
 void ElMuCategory::register_cuts(CutManager& manager) {
@@ -90,8 +90,8 @@ void ElMuCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const Produc
 }
 
 void ElMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
-    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
-    if( hh_analyzer.dileptons_emu[0].M() > 20. )
+    const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
+    if( dilepton_analyzer.dileptons_emu[0].M() > 20. )
         manager.pass_cut("ll_mass");
 }
 
@@ -104,8 +104,8 @@ bool ElElCategory::event_in_category_pre_analyzers(const ProducersManager& produ
 };
 
 bool ElElCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
-    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
-    return hh_analyzer.dielectrons.size() > 0;
+    const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
+    return dilepton_analyzer.dielectrons.size() > 0;
 };
 
 void ElElCategory::register_cuts(CutManager& manager) {
@@ -119,8 +119,8 @@ void ElElCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const Produc
 }
 
 void ElElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
-    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
-    if( hh_analyzer.dielectrons[0].M() > 20. )
+    const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
+    if( dilepton_analyzer.dielectrons[0].M() > 20. )
         manager.pass_cut("ll_mass");
 }
 

--- a/plugins/DileptonCategories.cc
+++ b/plugins/DileptonCategories.cc
@@ -15,7 +15,7 @@ bool MuMuCategory::event_in_category_pre_analyzers(const ProducersManager& produ
 
 bool MuMuCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
-    return dilepton_analyzer.dimuons.size() > 0;
+    return dilepton_analyzer.dileptons_mumu.size() > 0;
 };
 
 void MuMuCategory::register_cuts(CutManager& manager) {
@@ -30,7 +30,7 @@ void MuMuCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const Produc
 
 void MuMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
-    if( dilepton_analyzer.dimuons[0].M() > 20. )
+    if( dilepton_analyzer.dileptons_mumu[0].M() > 20. )
         manager.pass_cut("ll_mass");
 }
 
@@ -45,7 +45,7 @@ bool MuElCategory::event_in_category_pre_analyzers(const ProducersManager& produ
 
 bool MuElCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
-    return dilepton_analyzer.dileptons_mue.size() > 0;
+    return dilepton_analyzer.dileptons_muel.size() > 0;
 };
 
 void MuElCategory::register_cuts(CutManager& manager) {
@@ -60,7 +60,7 @@ void MuElCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const Produc
 
 void MuElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
-    if( dilepton_analyzer.dileptons_mue[0].M() > 20. )
+    if( dilepton_analyzer.dileptons_muel[0].M() > 20. )
         manager.pass_cut("ll_mass");
 }
 
@@ -75,7 +75,7 @@ bool ElMuCategory::event_in_category_pre_analyzers(const ProducersManager& produ
 
 bool ElMuCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
-    return dilepton_analyzer.dileptons_emu.size() > 0;
+    return dilepton_analyzer.dileptons_elmu.size() > 0;
 };
 
 void ElMuCategory::register_cuts(CutManager& manager) {
@@ -91,7 +91,7 @@ void ElMuCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const Produc
 
 void ElMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
-    if( dilepton_analyzer.dileptons_emu[0].M() > 20. )
+    if( dilepton_analyzer.dileptons_elmu[0].M() > 20. )
         manager.pass_cut("ll_mass");
 }
 
@@ -105,7 +105,7 @@ bool ElElCategory::event_in_category_pre_analyzers(const ProducersManager& produ
 
 bool ElElCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
-    return dilepton_analyzer.dielectrons.size() > 0;
+    return dilepton_analyzer.dileptons_elel.size() > 0;
 };
 
 void ElElCategory::register_cuts(CutManager& manager) {
@@ -120,7 +120,7 @@ void ElElCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const Produc
 
 void ElElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
-    if( dilepton_analyzer.dielectrons[0].M() > 20. )
+    if( dilepton_analyzer.dileptons_elel[0].M() > 20. )
         manager.pass_cut("ll_mass");
 }
 

--- a/plugins/DileptonCategories.cc
+++ b/plugins/DileptonCategories.cc
@@ -1,0 +1,126 @@
+#include <cp3_llbb/Framework/interface/MuonsProducer.h>
+#include <cp3_llbb/Framework/interface/ElectronsProducer.h>
+#include <cp3_llbb/Framework/interface/JetsProducer.h>
+
+#include <cp3_llbb/Framework/interface/DileptonCategories.h>
+#include <cp3_llbb/Framework/interface/DileptonAnalyzer.h>
+
+// ***** ***** *****
+// Dilepton Mu-Mu category
+// ***** ***** *****
+bool MuMuCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
+    const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
+    return muons.p4.size() >= 2 ;
+};
+
+bool MuMuCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
+    return hh_analyzer.dimuons.size() > 0;
+};
+
+void MuMuCategory::register_cuts(CutManager& manager) {
+    manager.new_cut("ll_mass", "mll > 20");
+};
+
+void MuMuCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const {
+    const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
+    if( (muons.p4[0] + muons.p4[1]).M() > 20.)
+        manager.pass_cut("ll_mass");
+}
+
+void MuMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
+    if( hh_analyzer.dimuons[0].M() > 20. )
+        manager.pass_cut("ll_mass");
+}
+
+// ***** ***** *****
+// Dilepton Mu-E category
+// ***** ***** *****
+bool MuElCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
+    const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
+    const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
+    return (muons.p4.size() >= 1) && (electrons.p4.size() >= 1);
+};
+
+bool MuElCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
+    return hh_analyzer.dileptons_mue.size() > 0;
+};
+
+void MuElCategory::register_cuts(CutManager& manager) {
+    manager.new_cut("ll_mass", "mll > 20");
+};
+void MuElCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const {
+    const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
+    const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
+    if( (muons.p4[0] + electrons.p4[0]).M() > 20.)
+        manager.pass_cut("ll_mass");
+}
+
+void MuElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
+    if( hh_analyzer.dileptons_mue[0].M() > 20. )
+        manager.pass_cut("ll_mass");
+}
+
+// ***** ***** *****
+// Dilepton E-Mu category
+// ***** ***** *****
+bool ElMuCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
+    const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
+    const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
+    return (muons.p4.size() >= 1) && (electrons.p4.size() >= 1);
+};
+
+bool ElMuCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
+    return hh_analyzer.dileptons_emu.size() > 0;
+};
+
+void ElMuCategory::register_cuts(CutManager& manager) {
+    manager.new_cut("ll_mass", "mll > 20");
+};
+
+void ElMuCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const {
+    const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
+    const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
+    if( (muons.p4[0] + electrons.p4[0]).M() > 20.)
+        manager.pass_cut("ll_mass");
+}
+
+void ElMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
+    if( hh_analyzer.dileptons_emu[0].M() > 20. )
+        manager.pass_cut("ll_mass");
+}
+
+// ***** ***** *****
+// Dilepton El-El category
+// ***** ***** *****
+bool ElElCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
+    const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
+    return electrons.p4.size() >= 2;
+};
+
+bool ElElCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
+    return hh_analyzer.dielectrons.size() > 0;
+};
+
+void ElElCategory::register_cuts(CutManager& manager) {
+    manager.new_cut("ll_mass", "mll > 20");
+};
+
+void ElElCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const {
+    const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
+    if( (electrons.p4[0] + electrons.p4[1]).M() > 20.)
+        manager.pass_cut("ll_mass");
+}
+
+void ElElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
+    if( hh_analyzer.dielectrons[0].M() > 20. )
+        manager.pass_cut("ll_mass");
+}
+

--- a/plugins/DileptonCategories.cc
+++ b/plugins/DileptonCategories.cc
@@ -22,12 +22,6 @@ void MuMuCategory::register_cuts(CutManager& manager) {
     manager.new_cut("ll_mass", "mll > 20");
 };
 
-void MuMuCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const {
-    const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
-    if( (muons.p4[0] + muons.p4[1]).M() > 20.)
-        manager.pass_cut("ll_mass");
-}
-
 void MuMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
     for(unsigned int idilepton = 0; idilepton < dilepton_analyzer.dileptons_mumu.size(); idilepton++)
@@ -55,12 +49,6 @@ bool MuElCategory::event_in_category_post_analyzers(const ProducersManager& prod
 void MuElCategory::register_cuts(CutManager& manager) {
     manager.new_cut("ll_mass", "mll > 20");
 };
-void MuElCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const {
-    const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
-    const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
-    if( (muons.p4[0] + electrons.p4[0]).M() > 20.)
-        manager.pass_cut("ll_mass");
-}
 
 void MuElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
@@ -90,13 +78,6 @@ void ElMuCategory::register_cuts(CutManager& manager) {
     manager.new_cut("ll_mass", "mll > 20");
 };
 
-void ElMuCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const {
-    const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
-    const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
-    if( (muons.p4[0] + electrons.p4[0]).M() > 20.)
-        manager.pass_cut("ll_mass");
-}
-
 void ElMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");
     for(unsigned int idilepton = 0; idilepton < dilepton_analyzer.dileptons_elmu.size(); idilepton++)
@@ -123,12 +104,6 @@ bool ElElCategory::event_in_category_post_analyzers(const ProducersManager& prod
 void ElElCategory::register_cuts(CutManager& manager) {
     manager.new_cut("ll_mass", "mll > 20");
 };
-
-void ElElCategory::evaluate_cuts_pre_analyzers(CutManager& manager, const ProducersManager& producers) const {
-    const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
-    if( (electrons.p4[0] + electrons.p4[1]).M() > 20.)
-        manager.pass_cut("ll_mass");
-}
 
 void ElElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton_analyzer");

--- a/test/TestConfigurationData.py
+++ b/test/TestConfigurationData.py
@@ -6,6 +6,12 @@ from cp3_llbb.Framework import Framework
 
 process = Framework.create(eras.Run2_50ns, '74X_dataRun2_Prompt_v1')
 
+process.framework.analyzers.dilepton = cms.PSet(
+        type = cms.string('dilepton_analyzer'),
+        prefix = cms.string('dilepton_'),
+        enable = cms.bool(True)
+        )
+
 process.framework.analyzers.test = cms.PSet(
         type = cms.string('test_analyzer'),
         prefix = cms.string('test_'),

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -5,6 +5,12 @@ from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 
 process = Framework.create(None, 'MCRUN2_74_V9', cms.PSet(
+    dilepton = cms.PSet(
+        type = cms.string('dilepton_analyzer'),
+        prefix = cms.string('dilepton_'),
+        enable = cms.bool(True)
+        )
+    )
     test = cms.PSet(
         type = cms.string('test_analyzer'),
         prefix = cms.string('test_'),


### PR DESCRIPTION
In my understanding this should be enough to run the dilepton_analyzer before the test_analyzer, but I am not sure what would need to be duplicated in the {TT,HH}Analysis packages to be sure it is run ?

~~I have one more commit I'd like to add before merging (renaming dimuons into dileptons_mumu, etc. for overall consistency)~~
Now good to go on my end