### PR TITLE
Add ability to specify the scheduling of analyzers. Fixes #34

### DIFF
--- a/python/Framework.py
+++ b/python/Framework.py
@@ -167,3 +167,26 @@ def create(era, globalTag=None, analyzers=cms.PSet()):
     #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     return process
+
+def schedule(process, analyzers):
+    """Inform the framework of the desired scheduling of the analyzers
+
+    Args:
+        process (cms.Process): the current framework process, return by the ``create`` method
+        analyzers (string tuple): a string array representing the desired scheduling of the analyzers. Analyzers will be executed in the specified order.
+    """
+
+    if analyzers is None or len(analyzers) == 0:
+        return process
+
+    framework_analyzers = process.framework.analyzers.parameterNames_()
+    for a in framework_analyzers:
+        if not a in analyzers:
+            raise Exception('Analyzer %r not found in your scheduling array. Please add it somewhere suitable for you.' % a)
+
+    if len(analyzers) != len(framework_analyzers):
+        raise Exception('Your scheduling array contains a different number of analyzers than the framework (%d vs %d)' % (len(analyzers), len(framework_analyzers)))
+
+    process.framework.analyzers_scheduling = cms.untracked.vstring(analyzers)
+
+    return process

--- a/test/TestConfigurationData.py
+++ b/test/TestConfigurationData.py
@@ -18,6 +18,8 @@ process.framework.analyzers.test = cms.PSet(
         enable = cms.bool(True)
         )
 
+Framework.schedule(process, ['dilepton', 'test'])
+
 process.source.fileNames = cms.untracked.vstring(
         '/store/data/Run2015B/DoubleMuon/MINIAOD/17Jul2015-v1/30000/D8ED75E7-C12E-E511-8CBF-0025905A608C.root'
         )

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -19,6 +19,8 @@ process = Framework.create(None, 'MCRUN2_74_V9', cms.PSet(
     )
     )
 
+Framework.schedule(process, ['dilepton', 'test'])
+
 process.source.fileNames = cms.untracked.vstring(
         'file:///home/fynu/sbrochet/storage/MINIAODSIM/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Asympt25ns_MCRUN2_74_V9_reduced.root'
         )


### PR DESCRIPTION
This introduces the possibility to change thee execution order of the analyzers. There's a new python method ``schedule``, which takes the process as well as a string array. This string array contains the analyzers' name in the order the user want them to be ran. It's the easiest and the more user-friendly solution I came with, if someone as something else, please speak :smile: 