### PR TITLE
Categories paramaters

### DIFF
--- a/interface/Analyzer.h
+++ b/interface/Analyzer.h
@@ -35,7 +35,7 @@ namespace Framework {
             virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const CategoryManager&) = 0;
             virtual void doConsumes(const edm::ParameterSet&, edm::ConsumesCollector&& collector) {}
 
-            virtual void registerCategories(CategoryManager& manager) {}
+            virtual void registerCategories(CategoryManager& manager, const edm::ParameterSet& config) {}
 
             virtual void beginJob(MetadataManager&) {}
             virtual void endJob(MetadataManager&) {}

--- a/interface/Category.h
+++ b/interface/Category.h
@@ -71,6 +71,10 @@ struct CategoryWrapper {
             return data.in_category_pre;
         }
 
+        bool cut_passed(const std::string& cut_name) const {
+            return data.cut_manager.cut_passed(cut_name);
+        }
+
         std::shared_ptr<CategoryMetadata> get_metadata() const {
             return data.callback->get_metadata();
         }

--- a/interface/Category.h
+++ b/interface/Category.h
@@ -19,6 +19,8 @@ struct CategoryMetadata {
 
 class Category {
     public:
+        virtual void configure(const edm::ParameterSet& config) {};
+
         virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const = 0;
         virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const = 0;
 
@@ -88,8 +90,9 @@ class CategoryManager {
 
     public:
         template<class T>
-        void new_category(const std::string& name, const std::string& description) {
+        void new_category(const std::string& name, const std::string& description, const edm::ParameterSet& config) {
             std::unique_ptr<Category> category(new T());
+            category->configure(config);
             m_categories.emplace(name, CategoryData(name, description, std::move(category), m_tree));
         }
 

--- a/interface/Cut.h
+++ b/interface/Cut.h
@@ -34,7 +34,7 @@ class CutManager {
 
         void new_cut(const std::string& name, const std::string& description);
         void pass_cut(const std::string& name);
-
+        bool cut_passed(const std::string& name) const;
     private:
         CategoryData& m_category;
         std::map<std::string, Cut> m_cuts;

--- a/interface/DileptonAnalyzer.h
+++ b/interface/DileptonAnalyzer.h
@@ -13,7 +13,7 @@ class DileptonAnalyzer: public Framework::Analyzer {
 
         virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const CategoryManager&) override;
 
-        virtual void registerCategories(CategoryManager& manager) override;
+        virtual void registerCategories(CategoryManager& manager, const edm::ParameterSet&) override;
 
         BRANCH(dileptons_mumu, std::vector<LorentzVector>);
         BRANCH(dileptons_elel, std::vector<LorentzVector>);

--- a/interface/DileptonCategories.h
+++ b/interface/DileptonCategories.h
@@ -3,7 +3,17 @@
 
 #include <cp3_llbb/Framework/interface/Category.h>
 
-class MuMuCategory: public Category {
+class DileptonCategory: public Category {
+    public:
+        virtual void configure(const edm::ParameterSet& conf) override {
+            m_mll_cut = conf.getUntrackedParameter<double>("mll_cut", 20);
+        }
+
+    protected:
+        float m_mll_cut;
+};
+
+class MuMuCategory: public DileptonCategory {
     public:
         virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
         virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
@@ -11,7 +21,7 @@ class MuMuCategory: public Category {
         virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
 };
 
-class MuElCategory: public Category {
+class MuElCategory: public DileptonCategory {
     public:
         virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
         virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
@@ -19,7 +29,7 @@ class MuElCategory: public Category {
         virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
 };
 
-class ElMuCategory: public Category {
+class ElMuCategory: public DileptonCategory {
     public:
         virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
         virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
@@ -27,7 +37,7 @@ class ElMuCategory: public Category {
         virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
 };
 
-class ElElCategory: public Category {
+class ElElCategory: public DileptonCategory {
     public:
         virtual bool event_in_category_pre_analyzers(const ProducersManager& producers) const override;
         virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;

--- a/interface/TestAnalyzer.h
+++ b/interface/TestAnalyzer.h
@@ -40,8 +40,8 @@ class TestAnalyzer: public Framework::Analyzer {
 
         virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const CategoryManager&) override;
 
-        virtual void registerCategories(CategoryManager& manager) {
-            manager.new_category<TwoMuonsCategory>("two_muons", "At least two muons category");
+        virtual void registerCategories(CategoryManager& manager, const edm::ParameterSet& config) {
+            manager.new_category<TwoMuonsCategory>("two_muons", "At least two muons category", config);
         }
 
     private:

--- a/src/Cut.cc
+++ b/src/Cut.cc
@@ -11,3 +11,12 @@ void CutManager::pass_cut(const std::string& name) {
     if (cut != m_cuts.end())
         cut->second.cut = true;
 }
+
+bool CutManager::cut_passed(const std::string& name) const {
+
+    const auto cut = m_cuts.find(name);
+    if (cut != m_cuts.end())
+        return cut->second.cut;
+
+    return false;
+}

--- a/src/DileptonAnalyzer.cc
+++ b/src/DileptonAnalyzer.cc
@@ -6,11 +6,11 @@
 #include <cp3_llbb/Framework/interface/MuonsProducer.h>
 
 
-void DileptonAnalyzer::registerCategories(CategoryManager& manager) {
-    manager.new_category<MuMuCategory>("mumu", "Category with leading leptons as two muons");
-    manager.new_category<ElElCategory>("elel", "Category with leading leptons as two electrons");
-    manager.new_category<MuElCategory>("muel", "Category with leading leptons as muon, electron");
-    manager.new_category<ElMuCategory>("elmu", "Category with leading leptons as electron, muon");
+void DileptonAnalyzer::registerCategories(CategoryManager& manager, const edm::ParameterSet& config) {
+    manager.new_category<MuMuCategory>("mumu", "Category with leading leptons as two muons", config);
+    manager.new_category<ElElCategory>("elel", "Category with leading leptons as two electrons", config);
+    manager.new_category<MuElCategory>("muel", "Category with leading leptons as muon, electron", config);
+    manager.new_category<ElMuCategory>("elmu", "Category with leading leptons as electron, muon", config);
 }
 
 void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const ProducersManager& producers, const CategoryManager& categories) {

--- a/src/DileptonCategories.cc
+++ b/src/DileptonCategories.cc
@@ -25,7 +25,7 @@ void MuMuCategory::register_cuts(CutManager& manager) {
 void MuMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton");
     for(unsigned int idilepton = 0; idilepton < dilepton_analyzer.dileptons_mumu.size(); idilepton++)
-        if( dilepton_analyzer.dileptons_mumu[idilepton].M() > 20. )
+        if( dilepton_analyzer.dileptons_mumu[idilepton].M() > m_mll_cut)
         {
             manager.pass_cut("ll_mass");
             break;
@@ -53,7 +53,7 @@ void MuElCategory::register_cuts(CutManager& manager) {
 void MuElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton");
     for(unsigned int idilepton = 0; idilepton < dilepton_analyzer.dileptons_muel.size(); idilepton++)
-        if( dilepton_analyzer.dileptons_muel[idilepton].M() > 20. )
+        if( dilepton_analyzer.dileptons_muel[idilepton].M() > m_mll_cut)
         {
             manager.pass_cut("ll_mass");
             break;
@@ -81,7 +81,7 @@ void ElMuCategory::register_cuts(CutManager& manager) {
 void ElMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton");
     for(unsigned int idilepton = 0; idilepton < dilepton_analyzer.dileptons_elmu.size(); idilepton++)
-        if( dilepton_analyzer.dileptons_elmu[idilepton].M() > 20. )
+        if( dilepton_analyzer.dileptons_elmu[idilepton].M() > m_mll_cut)
         {
             manager.pass_cut("ll_mass");
             break;
@@ -108,7 +108,7 @@ void ElElCategory::register_cuts(CutManager& manager) {
 void ElElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
     const DileptonAnalyzer& dilepton_analyzer = analyzers.get<DileptonAnalyzer>("dilepton");
     for(unsigned int idilepton = 0; idilepton < dilepton_analyzer.dileptons_elel.size(); idilepton++)
-        if( dilepton_analyzer.dileptons_elel[idilepton].M() > 20. )
+        if( dilepton_analyzer.dileptons_elel[idilepton].M() > m_mll_cut)
         {
             manager.pass_cut("ll_mass");
             break;

--- a/test/TestConfigurationData.py
+++ b/test/TestConfigurationData.py
@@ -9,7 +9,10 @@ process = Framework.create(eras.Run2_50ns, '74X_dataRun2_Prompt_v1')
 process.framework.analyzers.dilepton = cms.PSet(
         type = cms.string('dilepton_analyzer'),
         prefix = cms.string('dilepton_'),
-        enable = cms.bool(True)
+        enable = cms.bool(True),
+        categories_parameters = cms.PSet(
+            mll_cut = cms.untracked.double(20)
+            )
         )
 
 process.framework.analyzers.test = cms.PSet(

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -8,7 +8,10 @@ process = Framework.create(None, 'MCRUN2_74_V9', cms.PSet(
     dilepton = cms.PSet(
         type = cms.string('dilepton_analyzer'),
         prefix = cms.string('dilepton_'),
-        enable = cms.bool(True)
+        enable = cms.bool(True),
+        categories_parameters = cms.PSet(
+            mll_cut = cms.untracked.double(20)
+            )
         ),
 
     test = cms.PSet(


### PR DESCRIPTION
This PR adds a way to pass parameters to categories. A new callback function is added:

```C++
virtual void configure(const edm::ParameterSet& config)
```

The ``config`` parameter contains the python configuration specified in the analyzer configuration. It's red from the key ``categories_parameters``.

An example of usage is shown in the dilepton categories, where the ``mll`` cut is now red from the python configuration.