### PR TITLE
Add ability to redo JEC

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ cd ${CMSSW_BASE}/src
 # Electron ID as from [EGamma twiki (as on September 1st 2015)](https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2)
 git cms-merge-topic ikrav:egm_id_747_v2
 
+# Jet tool box
+git clone https://github.com/cms-jet/JetToolbox JMEAnalysis/JetToolbox
+
+# Backport of new pileup jet id. Not needed for CMSSW 7.4.12+
+git cms-merge-topic 11007
+
 # CP3-llbb framework itself
 git clone -o upstream git@github.com:blinkseb/TreeWrapper.git cp3_llbb/TreeWrapper
 git clone -o upstream git@github.com:cp3-llbb/Framework.git cp3_llbb/Framework

--- a/test/TestConfigurationData.py
+++ b/test/TestConfigurationData.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 
-process = Framework.create(eras.Run2_50ns, '74X_dataRun2_Prompt_v1')
+process = Framework.create(eras.Run2_50ns, '74X_dataRun2_v2', redoJEC=True)
 
 process.framework.analyzers.dilepton = cms.PSet(
         type = cms.string('dilepton_analyzer'),

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 
-process = Framework.create(None, 'MCRUN2_74_V9', cms.PSet(
+process = Framework.create(None, '74X_mcRun2_asymptotic_v2', cms.PSet(
     dilepton = cms.PSet(
         type = cms.string('dilepton_analyzer'),
         prefix = cms.string('dilepton_'),
@@ -19,7 +19,7 @@ process = Framework.create(None, 'MCRUN2_74_V9', cms.PSet(
         prefix = cms.string('test_'),
         enable = cms.bool(True)
         )
-    )
+    ), redoJEC=True
     )
 
 Framework.schedule(process, ['dilepton', 'test'])


### PR DESCRIPTION
Adds a new option to ``create``, ``redoJEC``, which will redo JEC if turned on. It's on by default to use latest released JEC. Global tags have also been updated.

Concerning the implementation: if ``redoJEC`` is true, jets are reclusterized from PF candidates using CHS. During this step, they are corrected using the JEC from the global tag, so if it's recent enough, newest JEC will be used. I've chosen to recluster the jet instead of simply change their p4 to ensure that all the related taggers are up-to-date with respect of the new pt of the jet (ie, pileup jet id, b-tagging?, etc.)

The MET collection is also redone, since we are using Type1 MET and jets have changed. It's recomputed from all the PF candidates, and Type I correction are applied using AK4 PF jets (non-CHS, as recommended by the JetMET POG).

I've successfully checked that the MiniAOD uncorrected met and the newly created uncorrected MET are exactly the same.