### PR TITLE
Add a flag to choose if dilepton analyzer uses categories or not

### DIFF
--- a/interface/DileptonAnalyzer.h
+++ b/interface/DileptonAnalyzer.h
@@ -8,7 +8,7 @@ class DileptonAnalyzer: public Framework::Analyzer {
     public:
         DileptonAnalyzer(const std::string& name, const ROOT::TreeGroup& tree_, const edm::ParameterSet& config):
             Analyzer(name, tree_, config) {
-
+                m_standalone_mode = config.getUntrackedParameter<bool>("standalone", false);
         }
 
         virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const CategoryManager&) override;
@@ -25,7 +25,7 @@ class DileptonAnalyzer: public Framework::Analyzer {
         BRANCH(dileptons_muel_indices, std::vector<std::pair<unsigned int,unsigned int>>);
 
     private:
-        // empty
+        bool m_standalone_mode = false;
 };
 
 

--- a/src/DileptonAnalyzer.cc
+++ b/src/DileptonAnalyzer.cc
@@ -7,10 +7,12 @@
 
 
 void DileptonAnalyzer::registerCategories(CategoryManager& manager, const edm::ParameterSet& config) {
-    manager.new_category<MuMuCategory>("mumu", "Category with leading leptons as two muons", config);
-    manager.new_category<ElElCategory>("elel", "Category with leading leptons as two electrons", config);
-    manager.new_category<MuElCategory>("muel", "Category with leading leptons as muon, electron", config);
-    manager.new_category<ElMuCategory>("elmu", "Category with leading leptons as electron, muon", config);
+    if (m_standalone_mode) {
+        manager.new_category<MuMuCategory>("mumu", "Category with leading leptons as two muons", config);
+        manager.new_category<ElElCategory>("elel", "Category with leading leptons as two electrons", config);
+        manager.new_category<MuElCategory>("muel", "Category with leading leptons as muon, electron", config);
+        manager.new_category<ElMuCategory>("elmu", "Category with leading leptons as electron, muon", config);
+    }
 }
 
 void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const ProducersManager& producers, const CategoryManager& categories) {

--- a/test/TestConfigurationData.py
+++ b/test/TestConfigurationData.py
@@ -12,6 +12,9 @@ process.framework.analyzers.dilepton = cms.PSet(
         enable = cms.bool(True),
         categories_parameters = cms.PSet(
             mll_cut = cms.untracked.double(20)
+            ),
+        parameters = cms.PSet(
+            standalone = cms.untracked.bool(True)
             )
         )
 

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -11,6 +11,9 @@ process = Framework.create(None, '74X_mcRun2_asymptotic_v2', cms.PSet(
         enable = cms.bool(True),
         categories_parameters = cms.PSet(
             mll_cut = cms.untracked.double(20)
+            ),
+        parameters = cms.PSet(
+            standalone = cms.untracked.bool(True)
             )
         ),
 


### PR DESCRIPTION
When running its own analysis and overriding dilepton categories, it's unwanted to have default categories ran (information is duplicated as the categories run twice). So, by default, do not register any categories when running the dilepton analyzer.

I think the next step is to transform this analyzer into a producer, but we'll need a way to schedule producers too.