### PR TITLE
Era from command-line

### DIFF
--- a/python/Framework.py
+++ b/python/Framework.py
@@ -112,11 +112,12 @@ def setup_met_(process, isData):
     del process.slimmedMETs.type1p2Uncertainties # not available
 
 
-def create(era, globalTag=None, analyzers=cms.PSet(), redoJEC=False):
+def create(isData, era, globalTag=None, analyzers=cms.PSet(), redoJEC=False):
     """Create the CMSSW python configuration for the Framework
 
     Args:
-        era (Configuration.StandardSequences.Eras.eras): The era of the data sample. Use ``None`` for simulated samples
+        isData (bool): Set to True if you run over data, or False for simulated samples
+        era (Configuration.StandardSequences.Eras.eras): The era of the sample. Used to distringuish between 50ns and 25ns
         globalTag (str): The global tag to use for this workflow. If set to ``None``, a command-line argument named ``globalTag`` must be specified
         analyzers (cms.PSet()): A list of analyzers to run. By default, it's empty, and you can still add one to the list afterwards.
         redoJEC (bool): If True, a new jet collection will be created, starting from MiniAOD jets but with latest JEC, pulled from the global tag.
@@ -134,13 +135,13 @@ def create(era, globalTag=None, analyzers=cms.PSet(), redoJEC=False):
         from cp3_llbb.Framework import Framework
 
         # Run on 50ns data sample
-        process = Framework.create(eras.Run2_50ns, '74X_dataRun2_Prompt_v1')
+        process = Framework.create(True, eras.Run2_50ns, '74X_dataRun2_Prompt_v1')
 
         # Run on 25ns data sample
-        process = Framework.create(eras.Run2_25ns, '74X_dataRun2_Prompt_v2')
+        process = Framework.create(True, eras.Run2_25ns, '74X_dataRun2_Prompt_v2')
 
-        # For MC
-        process = Framework.create(None, 'MCRUN2_74_V9', cms.PSet(
+        # For MC 50ns
+        process = Framework.create(False, eras.Run2_50ns, 'MCRUN2_74_V9', cms.PSet(
                 test = cms.PSet(
                     type = cms.string('test_analyzer'),
                     prefix = cms.string('test_'),
@@ -170,17 +171,12 @@ def create(era, globalTag=None, analyzers=cms.PSet(), redoJEC=False):
     if globalTag is None:
         raise Exception("No global tag specified. Use the 'globalTag' command line argument to set one.\n\tcmsRun <configuration> --globalTag=<global_tag>")
 
-    if era is not None:
-        process = cms.Process("ETM", era)
-    else:
-        process = cms.Process("ETM")
+    process = cms.Process("ETM", era)
 
     process.options = cms.untracked.PSet(
             wantSummary = cms.untracked.bool(False),
             allowUnscheduled = cms.untracked.bool(True)
             )
-
-    isData = era is not None
 
     process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
     process.load("Configuration.EventContent.EventContent_cff")

--- a/python/Framework.py
+++ b/python/Framework.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 def setup_jets_(process, isData, bTagDiscriminators):
     from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
@@ -255,6 +256,11 @@ def create(isData, era, globalTag=None, analyzers=cms.PSet(), redoJEC=False):
 
     process.framework.producers.jets.parameters.cut = cms.untracked.string("pt > 10")
     process.framework.producers.jets.parameters.btags = cms.untracked.vstring(bTagDiscriminators)
+
+    if era == eras.Run2_25ns:
+        process.framework.producers.electrons.parameters.ea_R03 = cms.untracked.FileInPath('RecoEgamma/ElectronIdentification/data/Spring15/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_25ns.txt')
+    else:
+        process.framework.producers.electrons.parameters.ea_R03 = cms.untracked.FileInPath('RecoEgamma/ElectronIdentification/data/Spring15/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_50ns.txt')
 
     path = cms.Path()
 

--- a/python/Framework.py
+++ b/python/Framework.py
@@ -152,25 +152,54 @@ def create(isData, era, globalTag=None, analyzers=cms.PSet(), redoJEC=False):
             )
     """
 
+    parseCommandLine = False
     import sys
     for argv in sys.argv:
-        if 'globalTag' in argv:
-
-            from FWCore.ParameterSet.VarParsing import VarParsing
-            options = VarParsing()
-            options.register('globalTag',
-                    '',
-                    VarParsing.multiplicity.singleton,
-                    VarParsing.varType.string,
-                    'The globaltag to use')
-
-            options.parseArguments()
-            globalTag = options.globalTag
-
+        if 'globalTag' in argv or 'era' in argv:
+            parseCommandLine = True
             break
 
+    if parseCommandLine:
+        from FWCore.ParameterSet.VarParsing import VarParsing
+        options = VarParsing()
+        options.register('globalTag',
+                '',
+                VarParsing.multiplicity.singleton,
+                VarParsing.varType.string,
+                'The globaltag to use')
+
+        options.register('era',
+                '',
+                VarParsing.multiplicity.singleton,
+                VarParsing.varType.string,
+                'Era of the dataset')
+
+        options.parseArguments()
+
+        if options.globalTag:
+            globalTag = options.globalTag
+
+        if options.era:
+            assert options.era == '25ns' or options.era == '50ns'
+            if options.era == '25ns':
+                era = eras.Run2_25ns
+            else:
+                era = eras.Run2_50ns
+
+
+
     if globalTag is None:
-        raise Exception("No global tag specified. Use the 'globalTag' command line argument to set one.\n\tcmsRun <configuration> --globalTag=<global_tag>")
+        raise Exception("No global tag specified. Use the 'globalTag' command line argument to set one.\n\tcmsRun <configuration> globalTag=<global_tag>")
+
+    if era is None:
+        raise Exception("No era specified. Use the 'era' command line argument to set one.\n\tcmsRun <configuration> era=[25ns|50ns]")
+
+    print("")
+    print("CP3 llbb framework:")
+    print("\t - Running over %s" % ("data" if isData else "simulation"))
+    print("\t - global tag: %s" % globalTag)
+    print("\t - era: %s" % ("25ns" if era == eras.Run2_25ns else "50ns"))
+    print("")
 
     process = cms.Process("ETM", era)
 

--- a/test/TestConfigurationData.py
+++ b/test/TestConfigurationData.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 
-process = Framework.create(eras.Run2_50ns, '74X_dataRun2_v2', redoJEC=True)
+process = Framework.create(True, eras.Run2_50ns, '74X_dataRun2_v2', redoJEC=True)
 
 process.framework.analyzers.dilepton = cms.PSet(
         type = cms.string('dilepton_analyzer'),

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 
-process = Framework.create(None, '74X_mcRun2_asymptotic_v2', cms.PSet(
+process = Framework.create(False, eras.Run2_25ns, '74X_mcRun2_asymptotic_v2', cms.PSet(
     dilepton = cms.PSet(
         type = cms.string('dilepton_analyzer'),
         prefix = cms.string('dilepton_'),


### PR DESCRIPTION
This PR extends the command line interface and adds the ability to specify the era along the global tag. It'll be used by the ``runOnGrid`` to switch between 50ns and 25ns samples.

First two commits are from #44.