### PR TITLE
Met cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 
 # Compiled bytecode of Python source files
 *.pyc
+python/__init__.py
 
 # Executables
 *.exe

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ git clone https://github.com/cms-jet/JetToolbox JMEAnalysis/JetToolbox
 # Backport of new pileup jet id. Not needed for CMSSW 7.4.12+
 git cms-merge-topic 11007
 
+# MET stuff
+git cms-merge-topic -u cms-met:METCorUnc74X
+
 # CP3-llbb framework itself
 git clone -o upstream git@github.com:blinkseb/TreeWrapper.git cp3_llbb/TreeWrapper
 git clone -o upstream git@github.com:cp3-llbb/Framework.git cp3_llbb/Framework

--- a/python/Framework.py
+++ b/python/Framework.py
@@ -40,11 +40,8 @@ def setup_met_(process, isData):
                 metSource = cms.InputTag("slimmedMETs", "" , cms.InputTag.skipCurrentProcess())
                 )
 
-    # MET is done from all PF candidates, and Type-I corrections are computed from non-CHS ak4 PF jets
-
-    ## Run AK4 PF jets without CHS
-    from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
-    jetToolbox(process, 'ak4', 'ak4JetSequence', 'out', PUMethod='Plain', runOnMC=not isData, miniAOD=True, addPUJetID=False, bTagDiscriminators=['jetProbabilityBJetTags'])
+    # MET is done from all PF candidates, and Type-I corrections are computed from CHS ak4 PF jets
+    # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETRun2Corrections#type_1_PF_MET_recommended
 
     ## Raw PF METs
     process.load('RecoMET.METProducers.PFMET_cfi')
@@ -58,13 +55,13 @@ def setup_met_(process, isData):
     from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import corrPfMetType1
     from JetMETCorrections.Type1MET.correctedMet_cff import pfMetT1
 
-    if not hasattr(process, 'ak4PFJets'):
-        print("WARNING: No AK4 jets produced. Type 1 corrections for MET are not available.")
+    if not hasattr(process, 'ak4PFJetsCHS'):
+        print("WARNING: No AK4 CHS jets produced. Type 1 corrections for MET are not available.")
     else:
         process.corrPfMetType1 = corrPfMetType1.clone(
-            src = 'ak4PFJets',
-            jetCorrLabel = 'ak4PFL1FastL2L3Corrector' if not isData else 'ak4PFL1FastL2L3ResidualCorrector',
-            offsetCorrLabel = 'ak4PFL1FastjetCorrector'
+            src = 'ak4PFJetsCHS',
+            jetCorrLabel = 'ak4PFCHSL1FastL2L3Corrector' if not isData else 'ak4PFCHSL1FastL2L3ResidualCorrector',
+            offsetCorrLabel = 'ak4PFCHSL1FastjetCorrector'
         )
         process.pfMetT1 = pfMetT1.clone(
             src = 'pfMet',

--- a/python/Framework.py
+++ b/python/Framework.py
@@ -35,26 +35,10 @@ def setup_met_(process, isData):
     from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
 
     ## Gen MET
-    ### Copied from https://github.com/cms-sw/cmssw/blob/2b75137e278b50fc967f95929388d430ef64710b/RecoMET/Configuration/python/GenMETParticles_cff.py#L37
-    process.genParticlesForMETAllVisible = cms.EDProducer(
-            "InputGenJetsParticleSelector",
-            src = cms.InputTag("prunedGenParticles"),
-            partonicFinalState = cms.bool(False),
-            excludeResonances = cms.bool(False),
-            excludeFromResonancePids = cms.vuint32(),
-            tausAsJets = cms.bool(False),
-
-            ignoreParticleIDs = cms.vuint32(
-                1000022,
-                1000012, 1000014, 1000016,
-                2000012, 2000014, 2000016,
-                1000039, 5100039,
-                4000012, 4000014, 4000016,
-                9900012, 9900014, 9900016,
-                39, 12, 14, 16
+    if not isData:
+        process.genMetExtractor = cms.EDProducer("GenMETExtractor",
+                metSource = cms.InputTag("slimmedMETs", "" , cms.InputTag.skipCurrentProcess())
                 )
-            )
-    process.load('RecoMET.METProducers.genMetTrue_cfi')
 
     # MET is done from all PF candidates, and Type-I corrections are computed from non-CHS ak4 PF jets
 
@@ -100,11 +84,15 @@ def setup_met_(process, isData):
     if hasattr(process, "patMET"):
         # Create MET from Type 1 PF collection
         process.patMET.addGenMET = not isData
+        if not isData:
+            process.patMET.genMETSource = cms.InputTag("genMetExtractor")
         process.slimmedMETs.src = cms.InputTag("patMET")
         process.slimmedMETs.rawUncertainties = cms.InputTag("patPFMet") # only central value
     else:
         # Create MET from RAW PF collection
         process.patPFMet.addGenMET = not isData
+        if not isData:
+            process.patPFMet.genMETSource = cms.InputTag("genMetExtractor")
         process.slimmedMETs.src = cms.InputTag("patPFMet")
         del process.slimmedMETs.rawUncertainties # not available
 


### PR DESCRIPTION
Two things in this PR:

 - Use genmet from miniaod instead of recomputing our own
 - For Run II, the recommendation is now to use CHS jets for Type1 corrections. See https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETRun2Corrections#type_1_PF_MET_recommended

Note: a new dependency is added to the README:

```
git cms-merge-topic -u cms-met:METCorUnc74X
```

It's merged in 7.4.12 IIRC (but see #38)