### PR TITLE
Add FatJetsProducer

### DIFF
--- a/interface/FatJetsProducer.h
+++ b/interface/FatJetsProducer.h
@@ -1,0 +1,86 @@
+#ifndef FAT_JETS_PRODUCER
+#define FAT_JETS_PRODUCER
+
+#include <cp3_llbb/Framework/interface/CandidatesProducer.h>
+#include <cp3_llbb/Framework/interface/BTaggingScaleFactors.h>
+
+#include <DataFormats/PatCandidates/interface/Jet.h>
+
+class FatJetsProducer: public CandidatesProducer<pat::Jet>, public BTaggingScaleFactors {
+    public:
+        FatJetsProducer(const std::string& name, const ROOT::TreeGroup& tree, const edm::ParameterSet& config):
+            CandidatesProducer(name, tree, config), BTaggingScaleFactors(const_cast<ROOT::TreeGroup&>(tree))
+        {
+            BTaggingScaleFactors::create_branches(config);
+
+            if (config.exists("btags")) {
+                const std::vector<std::string>& btags = config.getUntrackedParameter<std::vector<std::string>>("btags");
+
+                // Create branches
+                for (const std::string& btag: btags) {
+                    m_btag_discriminators.emplace(btag, &CandidatesProducer<pat::Jet>::tree[btag].write<std::vector<float>>());
+                }
+            }
+
+            if (config.exists("subjets_btags")) {
+                m_subjets_btag_discriminators = config.getUntrackedParameter<std::vector<std::string>>("subjets_btags");
+
+                // Create branches
+                for (const std::string& btag: m_subjets_btag_discriminators) {
+                    m_softdrop_btag_discriminators_branches.emplace(btag,
+                            &CandidatesProducer<pat::Jet>::tree["softdrop_" + btag].write<std::vector<std::vector<float>>>());
+                    m_toptag_btag_discriminators_branches.emplace(btag,
+                            &CandidatesProducer<pat::Jet>::tree["toptag_" + btag].write<std::vector<std::vector<float>>>());
+                }
+            }
+        }
+
+        virtual ~FatJetsProducer() {}
+
+        virtual void doConsumes(const edm::ParameterSet& config, edm::ConsumesCollector&& collector) override {
+            m_jets_token = collector.consumes<std::vector<pat::Jet>>(config.getUntrackedParameter<edm::InputTag>("jets", edm::InputTag("slimmedJetsAK8")));
+        }
+
+        virtual void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
+
+        float getBTagDiscriminant(size_t index, const std::string& name) const {
+            return m_btag_discriminators.at(name)->at(index);
+        }
+
+    private:
+
+        // Tokens
+        edm::EDGetTokenT<std::vector<pat::Jet>> m_jets_token;
+
+        std::map<std::string, std::vector<float>*> m_btag_discriminators;
+
+        std::vector<std::string> m_subjets_btag_discriminators;
+        std::map<std::string, std::vector<std::vector<float>>*> m_softdrop_btag_discriminators_branches;
+        std::map<std::string, std::vector<std::vector<float>>*> m_toptag_btag_discriminators_branches;
+    public:
+        // Tree members
+        std::vector<float>& area = tree["area"].write<std::vector<float>>();
+        std::vector<int8_t>& partonFlavor = tree["partonFlavor"].write<std::vector<int8_t>>();
+        std::vector<int8_t>& hadronFlavor = tree["hadronFlavor"].write<std::vector<int8_t>>();
+        std::vector<float>& jecFactor = tree["jecFactor"].write<std::vector<float>>();
+
+        BRANCH(tau1, std::vector<float>);
+        BRANCH(tau2, std::vector<float>);
+        BRANCH(tau3, std::vector<float>);
+
+        BRANCH(softdrop_mass, std::vector<float>);
+        BRANCH(trimmed_mass, std::vector<float>);
+        BRANCH(pruned_mass, std::vector<float>);
+        BRANCH(filtered_mass, std::vector<float>);
+
+        BRANCH(has_toptag_info, std::vector<bool>);
+        BRANCH(toptag_min_mass, std::vector<float>);
+        BRANCH(toptag_top_mass, std::vector<float>);
+        BRANCH(toptag_w_mass, std::vector<float>);
+        BRANCH(toptag_n_subjets, std::vector<uint8_t>);
+
+        BRANCH(toptag_subjets_p4, std::vector<std::vector<LorentzVector>>);
+        BRANCH(softdrop_subjets_p4, std::vector<std::vector<LorentzVector>>);
+};
+
+#endif

--- a/python/FatJetsProducer.py
+++ b/python/FatJetsProducer.py
@@ -1,0 +1,67 @@
+import FWCore.ParameterSet.Config as cms
+
+default_configuration = cms.PSet(
+        type = cms.string('fat_jets'),
+        prefix = cms.string('fatjet_'),
+        enable = cms.bool(True),
+        parameters = cms.PSet(
+            btags = cms.untracked.vstring('pfCombinedInclusiveSecondaryVertexV2BJetTags', 'pfJetProbabilityBJetTags', 'pfCombinedMVABJetTags'),
+            subjets_btags = cms.untracked.vstring('pfCombinedSecondaryVertexV2BJetTags', 'pfCombinedInclusiveSecondaryVertexV2BJetTags'),
+            scale_factors = cms.untracked.PSet(
+                csv_loose = cms.untracked.PSet(
+                    algorithm = cms.untracked.string('csv'),
+                    working_point = cms.untracked.string('loose'),
+                    files = cms.untracked.VPSet(
+                        cms.untracked.PSet(
+                            flavor = cms.untracked.string('bjets'),
+                            file = cms.untracked.FileInPath('cp3_llbb/Framework/data/ScaleFactors/BTagging_loose_bjets_comb_csv.json'),
+                            ),
+                        cms.untracked.PSet(
+                            flavor = cms.untracked.string('cjets'),
+                            file = cms.untracked.FileInPath('cp3_llbb/Framework/data/ScaleFactors/BTagging_loose_cjets_comb_csv.json'),
+                            ),
+                        cms.untracked.PSet(
+                            flavor = cms.untracked.string('lightjets'),
+                            file = cms.untracked.FileInPath('cp3_llbb/Framework/data/ScaleFactors/BTagging_loose_lightjets_comb_csv.json'),
+                            ),
+                        )
+                    ),
+                csv_medium = cms.untracked.PSet(
+                    algorithm = cms.untracked.string('csv'),
+                    working_point = cms.untracked.string('medium'),
+                    files = cms.untracked.VPSet(
+                        cms.untracked.PSet(
+                            flavor = cms.untracked.string('bjets'),
+                            file = cms.untracked.FileInPath('cp3_llbb/Framework/data/ScaleFactors/BTagging_medium_bjets_comb_csv.json'),
+                            ),
+                        cms.untracked.PSet(
+                            flavor = cms.untracked.string('cjets'),
+                            file = cms.untracked.FileInPath('cp3_llbb/Framework/data/ScaleFactors/BTagging_medium_cjets_comb_csv.json'),
+                            ),
+                        cms.untracked.PSet(
+                            flavor = cms.untracked.string('lightjets'),
+                            file = cms.untracked.FileInPath('cp3_llbb/Framework/data/ScaleFactors/BTagging_medium_lightjets_comb_csv.json'),
+                            ),
+                        )
+                    ),
+                csv_tight = cms.untracked.PSet(
+                    algorithm = cms.untracked.string('csv'),
+                    working_point = cms.untracked.string('tight'),
+                    files = cms.untracked.VPSet(
+                        cms.untracked.PSet(
+                            flavor = cms.untracked.string('bjets'),
+                            file = cms.untracked.FileInPath('cp3_llbb/Framework/data/ScaleFactors/BTagging_tight_bjets_comb_csv.json'),
+                            ),
+                        cms.untracked.PSet(
+                            flavor = cms.untracked.string('cjets'),
+                            file = cms.untracked.FileInPath('cp3_llbb/Framework/data/ScaleFactors/BTagging_tight_cjets_comb_csv.json'),
+                            ),
+                        cms.untracked.PSet(
+                            flavor = cms.untracked.string('lightjets'),
+                            file = cms.untracked.FileInPath('cp3_llbb/Framework/data/ScaleFactors/BTagging_tight_lightjets_comb_csv.json'),
+                            ),
+                        )
+                    )
+                )
+            )
+        )

--- a/python/Framework.py
+++ b/python/Framework.py
@@ -235,6 +235,7 @@ def create(isData, era, globalTag=None, analyzers=cms.PSet(), redoJEC=False):
     from cp3_llbb.Framework import GenParticlesProducer
     from cp3_llbb.Framework import HLTProducer
     from cp3_llbb.Framework import JetsProducer
+    from cp3_llbb.Framework import FatJetsProducer
     from cp3_llbb.Framework import METProducer
     from cp3_llbb.Framework import MuonsProducer
     from cp3_llbb.Framework import ElectronsProducer
@@ -256,6 +257,8 @@ def create(isData, era, globalTag=None, analyzers=cms.PSet(), redoJEC=False):
 
                 jets = JetsProducer.default_configuration,
 
+                fat_jets = FatJetsProducer.default_configuration,
+
                 met = METProducer.default_configuration,
 
                 muons = MuonsProducer.default_configuration,
@@ -270,6 +273,8 @@ def create(isData, era, globalTag=None, analyzers=cms.PSet(), redoJEC=False):
 
     process.framework.producers.jets.parameters.cut = cms.untracked.string("pt > 10")
     process.framework.producers.jets.parameters.btags = cms.untracked.vstring(bTagDiscriminators)
+
+    process.framework.producers.fat_jets.parameters.cut = cms.untracked.string("pt > 200")
 
     if era == eras.Run2_25ns:
         process.framework.producers.electrons.parameters.ea_R03 = cms.untracked.FileInPath('RecoEgamma/ElectronIdentification/data/Spring15/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_25ns.txt')

--- a/src/FatJetsProducer.cc
+++ b/src/FatJetsProducer.cc
@@ -1,0 +1,89 @@
+#include <cp3_llbb/Framework/interface/FatJetsProducer.h>
+#include <DataFormats/BTauReco/interface/CATopJetTagInfo.h>
+
+
+void FatJetsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup) {
+
+    edm::Handle<std::vector<pat::Jet>> jets;
+    event.getByToken(m_jets_token, jets);
+
+    for (const auto& jet: *jets) {
+        if (! pass_cut(jet))
+            continue;
+
+        fill_candidate(jet, jet.genJet());
+
+        jecFactor.push_back(jet.jecFactor(0));
+        area.push_back(jet.jetArea());
+        partonFlavor.push_back(jet.partonFlavour());
+        hadronFlavor.push_back(jet.hadronFlavour());
+
+        tau1.push_back(jet.userFloat("NjettinessAK8:tau1"));
+        tau2.push_back(jet.userFloat("NjettinessAK8:tau2"));
+        tau3.push_back(jet.userFloat("NjettinessAK8:tau3"));
+
+        softdrop_mass.push_back(jet.userFloat("ak8PFJetsCHSSoftDropMass"));
+        trimmed_mass.push_back(jet.userFloat("ak8PFJetsCHSTrimmedMass"));
+        pruned_mass.push_back(jet.userFloat("ak8PFJetsCHSPrunedMass"));
+        filtered_mass.push_back(jet.userFloat("ak8PFJetsCHSFilteredMass"));
+
+        reco::CATopJetTagInfo const * tagInfo =  dynamic_cast<reco::CATopJetTagInfo const *>(jet.tagInfo("caTop"));
+        if (tagInfo) {
+            has_toptag_info.push_back(true);
+            toptag_min_mass.push_back(tagInfo->properties().minMass);
+            toptag_top_mass.push_back(tagInfo->properties().topMass);
+            toptag_w_mass.push_back(tagInfo->properties().wMass);
+            toptag_n_subjets.push_back(tagInfo->properties().nSubJets);
+        } else {
+            has_toptag_info.push_back(false);
+            toptag_min_mass.push_back(0);
+            toptag_top_mass.push_back(0);
+            toptag_w_mass.push_back(0);
+            toptag_n_subjets.push_back(0);
+        }
+
+        // Subjets
+        // 1) SoftDrop
+        const auto& wSubjets = jet.subjets("SoftDrop");
+        std::map<std::string, std::vector<float>> subjets_btag_discriminators;
+        std::vector<LorentzVector> subjets_p4;
+        for (const auto& iw: wSubjets) {
+            subjets_p4.push_back(LorentzVector(iw->pt(), iw->eta(), iw->phi(), iw->energy()));
+            for (const auto& subjet_btag: m_subjets_btag_discriminators) {
+                subjets_btag_discriminators[subjet_btag].push_back(iw->bDiscriminator(subjet_btag));
+            }
+        }
+
+        softdrop_subjets_p4.push_back(subjets_p4);
+        for (const auto& it: subjets_btag_discriminators) {
+            m_softdrop_btag_discriminators_branches[it.first]->push_back(it.second);
+        }
+
+        // 2) Top tagger
+        const auto& wTopjets = jet.subjets("CMSTopTag");
+        subjets_p4.clear();
+        subjets_btag_discriminators.clear();
+        for (const auto& it: wTopjets) {
+            subjets_p4.push_back(LorentzVector(it->pt(), it->eta(), it->phi(), it->energy()));
+            for (const auto& subjet_btag: m_subjets_btag_discriminators) {
+                subjets_btag_discriminators[subjet_btag].push_back(it->bDiscriminator(subjet_btag));
+            }
+        }
+
+        toptag_subjets_p4.push_back(subjets_p4);
+        for (const auto& it: subjets_btag_discriminators) {
+            m_toptag_btag_discriminators_branches[it.first]->push_back(it.second);
+        }
+
+        for (auto& it: m_btag_discriminators) {
+
+            float btag_discriminator = jet.bDiscriminator(it.first);
+            it.second->push_back(btag_discriminator);
+
+            Algorithm algo = string_to_algorithm(it.first);
+            if (algo != Algorithm::UNKNOWN && BTaggingScaleFactors::has_scale_factors(algo)) {
+                BTaggingScaleFactors::store_scale_factors(algo, get_flavor(jet.hadronFlavour()), {static_cast<float>(fabs(jet.eta())), static_cast<float>(jet.pt()), btag_discriminator});
+            }
+        }
+    }
+}

--- a/src/Producers.cc
+++ b/src/Producers.cc
@@ -4,6 +4,7 @@
 #include <cp3_llbb/Framework/interface/EventProducer.h>
 #include <cp3_llbb/Framework/interface/HLTProducer.h>
 #include <cp3_llbb/Framework/interface/JetsProducer.h>
+#include <cp3_llbb/Framework/interface/FatJetsProducer.h>
 #include <cp3_llbb/Framework/interface/METProducer.h>
 #include <cp3_llbb/Framework/interface/MuonsProducer.h>
 #include <cp3_llbb/Framework/interface/ElectronsProducer.h>
@@ -13,6 +14,7 @@ DEFINE_EDM_PLUGIN(ExTreeMakerProducerFactory, GenParticlesProducer, "gen_particl
 DEFINE_EDM_PLUGIN(ExTreeMakerProducerFactory, EventProducer, "event");
 DEFINE_EDM_PLUGIN(ExTreeMakerProducerFactory, HLTProducer, "hlt");
 DEFINE_EDM_PLUGIN(ExTreeMakerProducerFactory, JetsProducer, "jets");
+DEFINE_EDM_PLUGIN(ExTreeMakerProducerFactory, FatJetsProducer, "fat_jets");
 DEFINE_EDM_PLUGIN(ExTreeMakerProducerFactory, METProducer, "met");
 DEFINE_EDM_PLUGIN(ExTreeMakerProducerFactory, MuonsProducer, "muons");
 DEFINE_EDM_PLUGIN(ExTreeMakerProducerFactory, ElectronsProducer, "electrons");

--- a/src/classes.h
+++ b/src/classes.h
@@ -1,6 +1,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <Math/Vector4D.h>
 
 namespace {
     struct dictionary {
@@ -10,5 +11,6 @@ namespace {
         std::vector<std::vector<uint16_t>> dummy4;
         std::vector<std::map<std::string, bool>> dummy5;
         std::pair<std::string, bool> dummy6;
+        std::vector<std::vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float>>>> dummy7;
     };
 }

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -3,5 +3,6 @@
     <class name="std::vector<int16_t>"/>
     <class name="std::vector<uint16_t>"/>
     <class name="std::vector<std::vector<uint16_t>>"/>
+    <class name="std::vector<std::vector<ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float>>>>"/>
     <class name="std::vector<std::map<std::string, bool>>"/>
 </lcgdict>


### PR DESCRIPTION
This PR adds support for fat jets. What is stored:

 - p4
 - btag of the fat jet
 - tau 1, 2 and 3
 - various masses (trimmed, pruned, etc.)
 - various top quantities
 - p4 and btag for the subjets produced by the Soft drop algorithm (used for Z/W/H tagging)
 - p4 and btag for the subjets produced by the CMS top tagger algo (used for... top tagging!)

If you see something missing, please tell me.