### PR TITLE
Support for producers scheduling

### DIFF
--- a/interface/Framework.h
+++ b/interface/Framework.h
@@ -50,11 +50,11 @@ class ExTreeMaker: public edm::EDProducer, ProducerGetter, AnalyzerGetter {
         std::string m_output_filename;
         std::unique_ptr<TFile> m_output;
         std::unique_ptr<ROOT::TreeWrapper> m_wrapper;
-        std::unordered_map<std::string, std::shared_ptr<Framework::Producer>> m_producers;
+
         std::unordered_map<std::string, std::shared_ptr<Framework::Filter>> m_filters;
 
-
         // Order is important, we can't use a map here
+        std::vector<std::pair<std::string, std::shared_ptr<Framework::Producer>>> m_producers;
         std::vector<std::shared_ptr<Framework::Analyzer>> m_analyzers;
         std::vector<std::string> m_analyzers_name;
 

--- a/python/Framework.py
+++ b/python/Framework.py
@@ -444,25 +444,35 @@ def create(isData, era, globalTag=None, analyzers=cms.PSet(), redoJEC=False):
     print("")
     return process
 
-def schedule(process, analyzers):
+def schedule(process, analyzers=None, producers=None):
     """Inform the framework of the desired scheduling of the analyzers
 
     Args:
         process (cms.Process): the current framework process, return by the ``create`` method
         analyzers (string tuple): a string array representing the desired scheduling of the analyzers. Analyzers will be executed in the specified order.
+        producers (string tuple): a string array representing the desired scheduling of the producers. Producers will be executed in the specified order.
     """
 
-    if analyzers is None or len(analyzers) == 0:
-        return process
+    if analyzers and len(analyzers) > 0:
+        framework_analyzers = process.framework.analyzers.parameterNames_()
+        for a in framework_analyzers:
+            if not a in analyzers:
+                raise Exception('Analyzer %r not found in your scheduling array. Please add it somewhere suitable for you.' % a)
 
-    framework_analyzers = process.framework.analyzers.parameterNames_()
-    for a in framework_analyzers:
-        if not a in analyzers:
-            raise Exception('Analyzer %r not found in your scheduling array. Please add it somewhere suitable for you.' % a)
+        if len(analyzers) != len(framework_analyzers):
+            raise Exception('Your scheduling array contains a different number of analyzers than the framework (%d vs %d)' % (len(analyzers), len(framework_analyzers)))
 
-    if len(analyzers) != len(framework_analyzers):
-        raise Exception('Your scheduling array contains a different number of analyzers than the framework (%d vs %d)' % (len(analyzers), len(framework_analyzers)))
+        process.framework.analyzers_scheduling = cms.untracked.vstring(analyzers)
 
-    process.framework.analyzers_scheduling = cms.untracked.vstring(analyzers)
+    if producers and len(producers) > 0:
+        framework_producers = process.framework.producers.parameterNames_()
+        for a in framework_producers:
+            if not a in producers:
+                raise Exception('Producer %r not found in your scheduling array. Please add it somewhere suitable for you.' % a)
+
+        if len(producers) != len(framework_producers):
+            raise Exception('Your scheduling array contains a different number of producers than the framework (%d vs %d)' % (len(producers), len(framework_producers)))
+
+        process.framework.producers_scheduling = cms.untracked.vstring(producers)
 
     return process

--- a/test/TestConfigurationData.py
+++ b/test/TestConfigurationData.py
@@ -62,7 +62,8 @@ process.framework.analyzers.bTagsTight = cms.PSet(
             )
         )
 
-Framework.schedule(process, ['dilepton', 'bTagsLoose', 'bTagsMedium', 'bTagsTight', 'test'])
+Framework.schedule(process, analyzers=['dilepton', 'bTagsLoose', 'bTagsMedium', 'bTagsTight', 'test'],
+        producers=['event', 'hlt', 'vertices', 'electrons', 'muons', 'jets', 'fat_jets', 'met', 'nohf_met'])
 
 process.source.fileNames = cms.untracked.vstring(
         '/store/data/Run2015B/DoubleMuon/MINIAOD/17Jul2015-v1/30000/D8ED75E7-C12E-E511-8CBF-0025905A608C.root'

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -66,7 +66,8 @@ process = Framework.create(False, eras.Run2_25ns, '74X_mcRun2_asymptotic_v2', cm
 
     )
 
-Framework.schedule(process, ['dilepton', 'bTagsLoose', 'bTagsMedium', 'bTagsTight', 'test'])
+Framework.schedule(process, analyzers=['dilepton', 'bTagsLoose', 'bTagsMedium', 'bTagsTight', 'test'],
+        producers=['event', 'gen_particles', 'hlt', 'vertices', 'electrons', 'muons', 'jets', 'fat_jets', 'met', 'nohf_met'])
 
 process.source.fileNames = cms.untracked.vstring(
         'file:///home/fynu/sbrochet/storage/MINIAODSIM/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Asympt25ns_MCRUN2_74_V9_reduced.root'


### PR DESCRIPTION
As title says. This will be useful to convert some analyzers into producers.

Note: this changes the python function Framework.schedule in order to add an additional named parameter. If we follow our proposed guideline, this means we should bump major version. Do we all agree on that?