### PR TITLE
Add a way to access other analyses from analyzers

### DIFF
--- a/interface/Analyzer.h
+++ b/interface/Analyzer.h
@@ -20,6 +20,7 @@
 #include <map>
 
 class CategoryManager;
+class AnalyzersManager;
 class ExTreeMaker;
 
 namespace Framework {
@@ -34,7 +35,7 @@ namespace Framework {
                 tree(tree_) {
                 }
 
-            virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const CategoryManager&) = 0;
+            virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const AnalyzersManager&, const CategoryManager&) = 0;
             virtual void doConsumes(const edm::ParameterSet&, edm::ConsumesCollector&& collector) {}
 
             virtual void registerCategories(CategoryManager& manager, const edm::ParameterSet& config) {}

--- a/interface/Analyzer.h
+++ b/interface/Analyzer.h
@@ -20,11 +20,15 @@
 #include <map>
 
 class CategoryManager;
+class ExTreeMaker;
 
 namespace Framework {
 
     class Analyzer {
+        friend class ::ExTreeMaker;
+
         public:
+
             Analyzer(const std::string& name, const ROOT::TreeGroup& tree_, const edm::ParameterSet& config):
                 m_name(name),
                 tree(tree_) {
@@ -47,6 +51,17 @@ namespace Framework {
         protected:
             std::string m_name;
             ROOT::TreeGroup tree;
+
+        private:
+            bool hasRun() const {
+                return m_run;
+            }
+
+            void setRun(bool run) {
+                m_run = run;
+            }
+
+            bool m_run; //< A flag indicating if the analyzer has already been run for this event
     };
 
 }

--- a/interface/BTagsAnalyzer.h
+++ b/interface/BTagsAnalyzer.h
@@ -14,7 +14,7 @@ class BTagsAnalyzer: public Framework::Analyzer {
             m_discr_name(config.getUntrackedParameter<std::string>("discr_name")) 
             { }
 
-        virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const CategoryManager&) override;
+        virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const AnalyzersManager&, const CategoryManager&) override;
 
         BRANCH(indices, std::vector<uint8_t>);
 

--- a/interface/DileptonAnalyzer.h
+++ b/interface/DileptonAnalyzer.h
@@ -22,7 +22,7 @@ class DileptonAnalyzer: public Framework::Analyzer {
                 m_electron_tight_wp_name = config.getUntrackedParameter<std::string>("electrons_tight_wp_name", "cutBasedElectronID-Spring15-50ns-V1-standalone-tight");
         }
 
-        virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const CategoryManager&) override;
+        virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const AnalyzersManager&, const CategoryManager&) override;
 
         virtual void registerCategories(CategoryManager& manager, const edm::ParameterSet&) override;
 

--- a/interface/Producer.h
+++ b/interface/Producer.h
@@ -17,9 +17,13 @@
 #include <vector>
 #include <map>
 
+class ExTreeMaker;
+
 namespace Framework {
 
     class Producer {
+        friend class ::ExTreeMaker;
+
         public:
             Producer(const std::string& name, const ROOT::TreeGroup& tree_, const edm::ParameterSet& config):
                 m_name(name),
@@ -41,6 +45,17 @@ namespace Framework {
         protected:
             std::string m_name;
             ROOT::TreeGroup tree;
+
+        private:
+            bool hasRun() const {
+                return m_run;
+            }
+
+            void setRun(bool run) {
+                m_run = run;
+            }
+
+            bool m_run; //< A flag indicating if the analyzer has already been run for this event
     };
 
 }

--- a/interface/TestAnalyzer.h
+++ b/interface/TestAnalyzer.h
@@ -38,7 +38,7 @@ class TestAnalyzer: public Framework::Analyzer {
 
         }
 
-        virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const CategoryManager&) override;
+        virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const AnalyzersManager&, const CategoryManager&) override;
 
         virtual void registerCategories(CategoryManager& manager, const edm::ParameterSet& config) {
             manager.new_category<TwoMuonsCategory>("two_muons", "At least two muons category", config);

--- a/plugins/TestAnalyzer.cc
+++ b/plugins/TestAnalyzer.cc
@@ -3,10 +3,14 @@
 #include <cp3_llbb/Framework/interface/GenParticlesProducer.h>
 #include <cp3_llbb/Framework/interface/JetsProducer.h>
 
+#include <cp3_llbb/Framework/interface/DileptonAnalyzer.h>
 
-void TestAnalyzer::analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager& producers, const CategoryManager& categories) {
+
+void TestAnalyzer::analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager& producers, const AnalyzersManager& analyzers, const CategoryManager& categories) {
 
     const JetsProducer& jets = producers.get<JetsProducer>("jets");
+
+    const DileptonAnalyzer& di = analyzers.get<DileptonAnalyzer>("dilepton");
 
 /*
     if (producers.exists("gen_particles")) {

--- a/src/BTagsAnalyzer.cc
+++ b/src/BTagsAnalyzer.cc
@@ -2,7 +2,7 @@
 
 #include <cp3_llbb/Framework/interface/JetsProducer.h>
 
-void BTagsAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const ProducersManager& producers, const CategoryManager& categories) {
+void BTagsAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const ProducersManager& producers, const AnalyzersManager& analyzers, const CategoryManager& categories) {
     
     const JetsProducer& jets = producers.get<JetsProducer>("jets");
 

--- a/src/DileptonAnalyzer.cc
+++ b/src/DileptonAnalyzer.cc
@@ -41,7 +41,7 @@ void DileptonAnalyzer::registerCategories(CategoryManager& manager, const edm::P
     }
 }
 
-void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const ProducersManager& producers, const CategoryManager& categories) {
+void DileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const ProducersManager& producers, const AnalyzersManager& analyzers, const CategoryManager& categories) {
 
 // ***** ***** *****
 // Get all dilepton objects out of the event

--- a/src/Framework.cc
+++ b/src/Framework.cc
@@ -192,7 +192,7 @@ void ExTreeMaker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     }
 
     for (auto& analyzer: m_analyzers) {
-        analyzer->analyze(iEvent, iSetup, *m_producers_manager, *m_categories);
+        analyzer->analyze(iEvent, iSetup, *m_producers_manager, *m_analyzers_manager, *m_categories);
         analyzer->setRun(true);
     }
 


### PR DESCRIPTION
As the title says. A new parameter is added to the analyze function. A check is also done to see if the analyzer or producer has already produced some data when trying to access it.

This break compatibility with analysis because of the added parameter.