### PR TITLE
Add very simple unit test to check that the framework is running

### DIFF
--- a/test/BuildFile.xml
+++ b/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<bin   name="Testcp3_llbbFramework" file="TestDriver.cc">
+  <flags TEST_RUNNER_ARGS="/bin/bash cp3_llbb/Framework/test run_tests.sh"/>
+  <use   name="FWCore/Utilities" />
+</bin>

--- a/test/TestDriver.cc
+++ b/test/TestDriver.cc
@@ -1,0 +1,3 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+
+RUNTEST()

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -5,3 +5,6 @@ function die { echo $1: status $2 ;  exit $2; }
 
 F1=${LOCAL_TEST_DIR}/unit_tests_mc.py
 (cmsRun $F1 ) || die "Failure using $F1" $?
+
+F2=${LOCAL_TEST_DIR}/unit_tests_data.py
+(cmsRun $F2 ) || die "Failure using $F2" $?

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+F1=${LOCAL_TEST_DIR}/unit_tests_mc.py
+(cmsRun $F1 ) || die "Failure using $F1" $?

--- a/test/unit_tests_data.py
+++ b/test/unit_tests_data.py
@@ -1,0 +1,13 @@
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+from cp3_llbb.Framework import Framework
+
+process = Framework.create(True, eras.Run2_50ns, '74X_dataRun2_v2', redoJEC=True)
+
+process.source.fileNames = cms.untracked.vstring(
+        'file:///afs/cern.ch/user/s/sbrochet/public/CP3/DoubleMuon-Run2015B-17Jul2015-v1-MiniAOD_reduced.root'
+        )
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))

--- a/test/unit_tests_mc.py
+++ b/test/unit_tests_mc.py
@@ -1,0 +1,13 @@
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+from cp3_llbb.Framework import Framework
+
+process = Framework.create(False, eras.Run2_25ns, '74X_mcRun2_asymptotic_v2', redoJEC=True)
+
+process.source.fileNames = cms.untracked.vstring(
+        'file:///afs/cern.ch/user/s/sbrochet/public/CP3/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Asympt25ns_MCRUN2_74_V9_reduced.root'
+        )
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))


### PR DESCRIPTION
This PR adds a way for Jenkins to actually run the framework and see if it's working or not.

For this, it uses CMSSW unit test integration that can be launched using ``scram b runtests``.

There's only a single test for the moment, running the framework without any analysis over a ttbar MC file, stored on afs (build-bot has not certificate :sob:). Others can be easily added, more code oriented using cppunit. We just need to find someone motivated to write those tests :smiley: 

Let's see if it works!