### PR TITLE
Add support for JEC databases

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -8,3 +8,7 @@ F1=${LOCAL_TEST_DIR}/unit_tests_mc.py
 
 F2=${LOCAL_TEST_DIR}/unit_tests_data.py
 (cmsRun $F2 ) || die "Failure using $F2" $?
+
+wget https://github.com/cms-jet/JECDatabase/raw/master/SQLiteFiles/Summer15_25nsV5_MC.db
+F3=${LOCAL_TEST_DIR}/unit_tests_mc_with_db.py
+(cmsRun $F3 ) || die "Failure using $F3" $?

--- a/test/unit_tests_mc_with_db.py
+++ b/test/unit_tests_mc_with_db.py
@@ -1,0 +1,13 @@
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+from cp3_llbb.Framework import Framework
+
+process = Framework.create(False, eras.Run2_25ns, '74X_mcRun2_asymptotic_v2', redoJEC=True, JECDatabase='Summer15_25nsV5_MC.db')
+
+process.source.fileNames = cms.untracked.vstring(
+        'file:///afs/cern.ch/user/s/sbrochet/public/CP3/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_RunIISpring15MiniAODv2_reduced.root'
+        )
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))


### PR DESCRIPTION
A new argument is added to the `create` function. If set, it should contains the name of the database where the JECs will be read (All these database are now stored [here](https://github.com/cms-jet/JECDatabase/tree/master/SQLiteFiles)).

It's the responsibility of the analyzers to download and correctly set this argument to the value they want.

This also needs some changes in GridIn to handle the new input file (the database must be send by crab with the others files). This is handled by introducing a new _super_ variable, `process.gridin`. This variable will be read by GridIn when submitting the jobs. All the files added to the `input_files` member will automatically be sent by crab.
