### PR TITLE
Make pruned particles branches transient (closes #83)

### DIFF
--- a/interface/GenParticlesProducer.h
+++ b/interface/GenParticlesProducer.h
@@ -36,12 +36,12 @@ class GenParticlesProducer: public Framework::Producer {
 
     public:
         // Tree members
-        std::vector<LorentzVector>& packed_p4 = tree_packed["p4"].write<std::vector<LorentzVector>>();
-        std::vector<float>& packed_y = tree_packed["y"].write<std::vector<float>>();
-        std::vector<int16_t>& packed_pdg_id = tree_packed["pdg_id"].write<std::vector<int16_t>>();
-        std::vector<int8_t>& packed_status = tree_packed["status"].write<std::vector<int8_t>>();
-        std::vector<int16_t>& packed_status_flags = tree_packed["status_flags"].write<std::vector<int16_t>>();
-        std::vector<std::vector<uint16_t>>& packed_mothers_index = tree_packed["mothers_index"].write<std::vector<std::vector<uint16_t>>>();
+        std::vector<LorentzVector>& packed_p4 = tree_packed["p4"].transient_write<std::vector<LorentzVector>>();
+        std::vector<float>& packed_y = tree_packed["y"].transient_write<std::vector<float>>();
+        std::vector<int16_t>& packed_pdg_id = tree_packed["pdg_id"].transient_write<std::vector<int16_t>>();
+        std::vector<int8_t>& packed_status = tree_packed["status"].transient_write<std::vector<int8_t>>();
+        std::vector<int16_t>& packed_status_flags = tree_packed["status_flags"].transient_write<std::vector<int16_t>>();
+        std::vector<std::vector<uint16_t>>& packed_mothers_index = tree_packed["mothers_index"].transient_write<std::vector<std::vector<uint16_t>>>();
 
         std::vector<LorentzVector>& pruned_p4 = tree_pruned["p4"].write<std::vector<LorentzVector>>();
         std::vector<float>& pruned_y = tree_pruned["y"].write<std::vector<float>>();

--- a/interface/Types.h
+++ b/interface/Types.h
@@ -3,5 +3,6 @@
 #include <Math/Vector4D.h>
 
 #define BRANCH(NAME, ...) __VA_ARGS__& NAME = tree[#NAME].write<__VA_ARGS__>()
+#define TRANSIENT_BRANCH(NAME, ...) __VA_ARGS__& NAME = tree[#NAME].transient_write<__VA_ARGS__>()
 
 typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float>> LorentzVector;


### PR DESCRIPTION
As discussed in #83. You'll need to update `TreeWrapper` to v1.1 (a `git pull` is enough). As expected, output size is reduced a lot:

```
Statistics for tree /t
******************************************************************************
*Tree    :t         : t                                                      *
*Entries :     1000 : Total =    18.7 MB  File  Size =     6.0 MB  ~ 99.86 % *
*        :          : Tree compression factor =   3.09                       *
******************************************************************************
branch pruned_gen_particle_p4                                          1.4 MB    ~23.28 %
branch tt_diJets                                                       555 kB    ~9.01 %
branch pruned_gen_particle_y                                           361 kB    ~5.86 %
branch tt_diLepDiJetsMet                                               358 kB    ~5.82 %
branch event_lhe_weights                                               322 kB    ~5.23 %
branch vertex_covariance                                               288 kB    ~4.69 %
branch vertex_position                                                 206 kB    ~3.35 %
branch pruned_gen_particle_mothers_index                               204 kB    ~3.31 %
branch jet_p4                                                          191 kB    ~3.10 %
branch jet_gen_p4                                                      168 kB    ~2.73 %
branch tt_diLepDiJets                                                  130 kB    ~2.11 %
branch pruned_gen_particle_pdg_id                                       78 kB    ~1.26 %
```

We are now a about 6 kb / event, more than 2x smaller than when keeping packed particles.
