### PR TITLE
PU info collection name changed in MiniAODv2

### DIFF
--- a/python/EventProducer.py
+++ b/python/EventProducer.py
@@ -5,5 +5,6 @@ default_configuration = cms.PSet(
         prefix = cms.string('event_'),
         enable = cms.bool(True),
         parameters = cms.PSet(
+            pu_summary = cms.untracked.InputTag('slimmedAddPileupInfo')
             )
         )


### PR DESCRIPTION
The name changed from `addPileupInfo` to `slimmedAddPileupInfo`. This is needed to get the number of true interactions for PU reweighting (currently it's always 0 when running on MiniAODv2 since the collection is not found).
