### PR TITLE
Modifying the code to get leptons and BTagging SF=1 for data

### DIFF
--- a/interface/BTaggingScaleFactors.h
+++ b/interface/BTaggingScaleFactors.h
@@ -43,7 +43,7 @@ class BTaggingScaleFactors {
 
         virtual void create_branches(const edm::ParameterSet&) final;
 
-        virtual void store_scale_factors(Algorithm algo, Flavor flavor, const std::vector<float>& values) final;
+        virtual void store_scale_factors(Algorithm algo, Flavor flavor, const std::vector<float>& values,bool isData) final;
 
         virtual float get_scale_factor(Algorithm algo, const std::string& wp, size_t index, Variation variation = Variation::Nominal) final;
 

--- a/interface/JetsProducer.h
+++ b/interface/JetsProducer.h
@@ -32,6 +32,7 @@ class JetsProducer: public CandidatesProducer<pat::Jet>, public BTaggingScaleFac
 
         virtual void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
+
         float getBTagDiscriminant(size_t index, const std::string& name) const {
             return m_btag_discriminators.at(name)->at(index);
         }

--- a/interface/ScaleFactors.h
+++ b/interface/ScaleFactors.h
@@ -26,7 +26,7 @@ class ScaleFactors {
         virtual void create_branches(const edm::ParameterSet&) final;
         virtual void create_branch(const std::string& scale_factor, const std::string& branch_name);
 
-        virtual void store_scale_factors(const std::vector<float>& values) final;
+        virtual void store_scale_factors(const std::vector<float>& values,bool isData) final;
 
         virtual float get_scale_factor(const std::string& tag, size_t index, Variation variation = Variation::Nominal) final;
 

--- a/src/BTaggingScaleFactors.cc
+++ b/src/BTaggingScaleFactors.cc
@@ -58,7 +58,7 @@ void BTaggingScaleFactors::create_branches(const edm::ParameterSet& config) {
 
 }
 
-void BTaggingScaleFactors::store_scale_factors(Algorithm algo_, Flavor flavor, const std::vector<float>& values) {
+void BTaggingScaleFactors::store_scale_factors(Algorithm algo_, Flavor flavor, const std::vector<float>& values,const bool isData) {
 
     auto algo_it = m_algos.find(algo_);
     if (algo_it == m_algos.end())
@@ -69,7 +69,9 @@ void BTaggingScaleFactors::store_scale_factors(Algorithm algo_, Flavor flavor, c
         branch_key_type branch_key = std::make_tuple(algo_, wp);
 
         std::vector<float> sfs = m_scale_factors[sf_key].get(values);
-        if (sfs.empty())
+        if(isData)
+		(*m_branches[branch_key]).push_back({1., 0., 0.});
+        else if (sfs.empty())
             (*m_branches[branch_key]).push_back({0., 0., 0.});
         else
             (*m_branches[branch_key]).push_back(sfs);

--- a/src/ElectronsProducer.cc
+++ b/src/ElectronsProducer.cc
@@ -40,7 +40,7 @@ void ElectronsProducer::produce(edm::Event& event, const edm::EventSetup& eventS
         dxy.push_back(electron.gsfTrack()->dxy(primary_vertex.position()));
         dz.push_back(electron.gsfTrack()->dz(primary_vertex.position()));
 
-        ScaleFactors::store_scale_factors({static_cast<float>(fabs(electron.eta())), static_cast<float>(electron.pt())});
+        ScaleFactors::store_scale_factors({static_cast<float>(fabs(electron.eta())), static_cast<float>(electron.pt())},event.isRealData());
     }
     Identifiable::clean();
 }

--- a/src/FatJetsProducer.cc
+++ b/src/FatJetsProducer.cc
@@ -86,7 +86,7 @@ void FatJetsProducer::produce(edm::Event& event, const edm::EventSetup& eventSet
 
             Algorithm algo = string_to_algorithm(it.first);
             if (algo != Algorithm::UNKNOWN && BTaggingScaleFactors::has_scale_factors(algo)) {
-                BTaggingScaleFactors::store_scale_factors(algo, get_flavor(jet.hadronFlavour()), {static_cast<float>(fabs(jet.eta())), static_cast<float>(jet.pt()), btag_discriminator});
+                BTaggingScaleFactors::store_scale_factors(algo, get_flavor(jet.hadronFlavour()), {static_cast<float>(fabs(jet.eta())), static_cast<float>(jet.pt()), btag_discriminator},event.isRealData());
             }
         }
     }

--- a/src/JetsProducer.cc
+++ b/src/JetsProducer.cc
@@ -33,7 +33,7 @@ void JetsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
 
             Algorithm algo = string_to_algorithm(it.first);
             if (algo != Algorithm::UNKNOWN && BTaggingScaleFactors::has_scale_factors(algo)) {
-                BTaggingScaleFactors::store_scale_factors(algo, get_flavor(jet.hadronFlavour()), {static_cast<float>(fabs(jet.eta())), static_cast<float>(jet.pt()), btag_discriminator});
+                BTaggingScaleFactors::store_scale_factors(algo, get_flavor(jet.hadronFlavour()), {static_cast<float>(fabs(jet.eta())), static_cast<float>(jet.pt()), btag_discriminator},event.isRealData());
             }
         }
     }

--- a/src/MuonsProducer.cc
+++ b/src/MuonsProducer.cc
@@ -40,6 +40,6 @@ void MuonsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup
         dxy.push_back(muon.muonBestTrack()->dxy(primary_vertex.position()));
         dz.push_back(muon.muonBestTrack()->dz(primary_vertex.position()));
 
-        ScaleFactors::store_scale_factors({static_cast<float>(fabs(muon.eta())), static_cast<float>(muon.pt())});
+        ScaleFactors::store_scale_factors({static_cast<float>(fabs(muon.eta())), static_cast<float>(muon.pt())},event.isRealData());
     }
 }

--- a/src/ScaleFactors.cc
+++ b/src/ScaleFactors.cc
@@ -26,10 +26,12 @@ void ScaleFactors::create_branch(const std::string& scale_factor, const std::str
         m_branches.emplace(scale_factor, & m_tree[branch_name].write<std::vector<std::vector<float>>>());
 }
 
-void ScaleFactors::store_scale_factors(const std::vector<float>& values) {
+void ScaleFactors::store_scale_factors(const std::vector<float>& values,bool isData) {
     for (const auto& sf: m_scale_factors) {
         std::vector<float> v = sf.second.get(values);
-        if (v.empty())
+	if(isData)
+	     (*m_branches[sf.first]).push_back({1., 0., 0.});
+        else if (v.empty())
             (*m_branches[sf.first]).push_back({0., 0., 0.});
         else
             (*m_branches[sf.first]).push_back(v);


### PR DESCRIPTION
This is one possible method to get the btagging SF=1 when running on the data. The member isRealData() of edm::Event is simply used as an argument of store_scale_factor(..), and the choice of filling with the values of the SF JSONs or to use (1,0,0) is done based in the value of isRealData().
