### PR TITLE
Ensure a valid scale factor is stored for all objects

### DIFF
--- a/BuildFile.xml
+++ b/BuildFile.xml
@@ -12,3 +12,4 @@
 <export>
     <lib name="1"/>
 </export>
+<flags CXXFLAGS="-g" />

--- a/interface/ScaleFactor.h
+++ b/interface/ScaleFactor.h
@@ -49,6 +49,9 @@ struct ScaleFactor {
     public:
     std::vector<float> get(const std::vector<float>& variables) const {
         if (!use_formula) {
+            if (! binned.get())
+                return {0., 0., 0.};
+
             std::vector<float> values = get<float>(*binned.get(), variables);
 
             if (absolute_errors && !values.empty()) {
@@ -58,6 +61,9 @@ struct ScaleFactor {
 
             return values;
         } else {
+            if (! formula.get())
+                return {0., 0., 0.};
+
             std::vector<std::shared_ptr<TFormula>> formulas = get<std::shared_ptr<TFormula>>(*formula.get(), variables);
             std::vector<float> values;
             for (auto& formula: formulas) {

--- a/interface/ScaleFactor.h
+++ b/interface/ScaleFactor.h
@@ -48,15 +48,23 @@ struct ScaleFactor {
 
     public:
     std::vector<float> get(const std::vector<float>& variables) const {
+        auto relative_to_absolute = [](const std::vector<float>& array) {
+            std::vector<float> result(3);
+            result[0] = array[0];
+            result[1] = array[0] + array[1];
+            result[2] = array[0] - array[2];
+
+            return result;
+        };
+
         if (!use_formula) {
             if (! binned.get())
                 return {0., 0., 0.};
 
             std::vector<float> values = get<float>(*binned.get(), variables);
 
-            if (absolute_errors && !values.empty()) {
-                values[1] = fabs(values[1] - values[0]);    
-                values[2] = fabs(values[0] - values[2]);
+            if (!absolute_errors && !values.empty()) {
+                values = relative_to_absolute(values);
             }
 
             return values;
@@ -70,9 +78,8 @@ struct ScaleFactor {
                 values.push_back(formula->Eval(variables[formula_variable_index]));
             }
 
-            if (absolute_errors && !values.empty()) {
-                values[1] = fabs(values[1] - values[0]);    
-                values[2] = fabs(values[0] - values[2]);
+            if (!absolute_errors && !values.empty()) {
+                values = relative_to_absolute(values);
             }
 
             return values;

--- a/src/BTaggingScaleFactors.cc
+++ b/src/BTaggingScaleFactors.cc
@@ -89,18 +89,5 @@ float BTaggingScaleFactors::get_scale_factor(Algorithm algo, const std::string& 
     if (index >= sf->second->size())
         return 0;
 
-    switch (variation) {
-        case Variation::Nominal:
-            return (*sf->second)[index][0];
-
-        case Variation::Down:
-            return (*sf->second)[index][0] - (*sf->second)[index][1];
-
-        case Variation::Up:
-            return (*sf->second)[index][0] + (*sf->second)[index][2];
-
-        default:
-            return 0;
-    }
-    return 0;
+    return (*sf->second)[index][static_cast<size_t>(variation)];
 }

--- a/src/BTaggingScaleFactors.cc
+++ b/src/BTaggingScaleFactors.cc
@@ -68,13 +68,10 @@ void BTaggingScaleFactors::store_scale_factors(Algorithm algo_, Flavor flavor, c
         sf_key_type sf_key = std::make_tuple(algo_, flavor, wp);
         branch_key_type branch_key = std::make_tuple(algo_, wp);
 
-        std::vector<float> sfs = m_scale_factors[sf_key].get(values);
-        if(isData)
-		(*m_branches[branch_key]).push_back({1., 0., 0.});
-        else if (sfs.empty())
-            (*m_branches[branch_key]).push_back({0., 0., 0.});
+        if (isData)
+            (*m_branches[branch_key]).push_back({1., 0., 0.});
         else
-            (*m_branches[branch_key]).push_back(sfs);
+            (*m_branches[branch_key]).push_back(m_scale_factors[sf_key].get(values));
     }
 }
 

--- a/src/ScaleFactors.cc
+++ b/src/ScaleFactors.cc
@@ -46,18 +46,5 @@ float ScaleFactors::get_scale_factor(const std::string& name, size_t index, Vari
     if (index >= sf->second->size())
         return 0;
 
-    switch (variation) {
-        case Variation::Nominal:
-            return (*sf->second)[index][0];
-
-        case Variation::Down:
-            return (*sf->second)[index][0] - (*sf->second)[index][1];
-
-        case Variation::Up:
-            return (*sf->second)[index][0] + (*sf->second)[index][2];
-
-        default:
-            return 0;
-    }
-    return 0;
+    return (*sf->second)[index][static_cast<size_t>(variation)];
 }

--- a/src/ScaleFactors.cc
+++ b/src/ScaleFactors.cc
@@ -28,13 +28,10 @@ void ScaleFactors::create_branch(const std::string& scale_factor, const std::str
 
 void ScaleFactors::store_scale_factors(const std::vector<float>& values,bool isData) {
     for (const auto& sf: m_scale_factors) {
-        std::vector<float> v = sf.second.get(values);
-	if(isData)
-	     (*m_branches[sf.first]).push_back({1., 0., 0.});
-        else if (v.empty())
-            (*m_branches[sf.first]).push_back({0., 0., 0.});
+        if (isData)
+            (*m_branches[sf.first]).push_back({1., 0., 0.});
         else
-            (*m_branches[sf.first]).push_back(v);
+            (*m_branches[sf.first]).push_back(sf.second.get(values));
     }
 }
 


### PR DESCRIPTION
Currently, if no scale factor is found for an object, 0 is stored. This PR changes this by looking for the closest bin in the SF space and use the value associated with this bin for the scale factor. For the errors, twice the value is used in this case.

I've also fixed a possible crash when using a empty ScaleFactor class.
