### PR TITLE
Protect against NaN b-tag discriminant. Fixes #99

### DIFF
--- a/interface/ScaleFactor.h
+++ b/interface/ScaleFactor.h
@@ -30,7 +30,16 @@ struct ScaleFactor {
         std::vector<_Value> get(Histogram<_Value, float>& h, const std::vector<float>& bins, bool& outOfRange) const {
             std::size_t bin = h.findClosestBin(bins, &outOfRange);
             if (bin == 0) {
-                throw std::runtime_error("Failed to found the right bin for a scale-factor. This should not happend");
+                std::stringstream msg;
+                msg << "Failed to found the right bin for a scale-factor. This should not happend. Bins: [";
+                for (float b: bins) {
+                    msg << b << ", ";
+                }
+
+                msg.seekp(msg.tellp() - 2l);
+                msg << "]";
+
+                throw std::runtime_error(msg.str());
             }
 
             return {h.getBinContent(bin), h.getBinErrorLow(bin), h.getBinErrorHigh(bin)};

--- a/src/FatJetsProducer.cc
+++ b/src/FatJetsProducer.cc
@@ -82,11 +82,15 @@ void FatJetsProducer::produce(edm::Event& event, const edm::EventSetup& eventSet
         for (auto& it: m_btag_discriminators) {
 
             float btag_discriminator = jet.bDiscriminator(it.first);
+            // Protect against NaN discriminant
+            if (std::isnan(btag_discriminator))
+                btag_discriminator = -10;
+
             it.second->push_back(btag_discriminator);
 
             Algorithm algo = string_to_algorithm(it.first);
             if (algo != Algorithm::UNKNOWN && BTaggingScaleFactors::has_scale_factors(algo)) {
-                BTaggingScaleFactors::store_scale_factors(algo, get_flavor(jet.hadronFlavour()), {static_cast<float>(fabs(jet.eta())), static_cast<float>(jet.pt()), btag_discriminator},event.isRealData());
+                BTaggingScaleFactors::store_scale_factors(algo, get_flavor(jet.hadronFlavour()), {static_cast<float>(std::abs(jet.eta())), static_cast<float>(jet.pt()), btag_discriminator}, event.isRealData());
             }
         }
     }

--- a/src/JetsProducer.cc
+++ b/src/JetsProducer.cc
@@ -29,11 +29,15 @@ void JetsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
         for (auto& it: m_btag_discriminators) {
 
             float btag_discriminator = jet.bDiscriminator(it.first);
+            // Protect against NaN discriminant
+            if (std::isnan(btag_discriminator))
+                btag_discriminator = -10;
+
             it.second->push_back(btag_discriminator);
 
             Algorithm algo = string_to_algorithm(it.first);
             if (algo != Algorithm::UNKNOWN && BTaggingScaleFactors::has_scale_factors(algo)) {
-                BTaggingScaleFactors::store_scale_factors(algo, get_flavor(jet.hadronFlavour()), {static_cast<float>(fabs(jet.eta())), static_cast<float>(jet.pt()), btag_discriminator},event.isRealData());
+                BTaggingScaleFactors::store_scale_factors(algo, get_flavor(jet.hadronFlavour()), {static_cast<float>(std::abs(jet.eta())), static_cast<float>(jet.pt()), btag_discriminator}, event.isRealData());
             }
         }
     }

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -73,4 +73,12 @@ process.source.fileNames = cms.untracked.vstring(
         '/store/mc/RunIISpring15MiniAODv2/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/00000/0014DC94-DC5C-E511-82FB-7845C4FC39F5.root'
         )
 
+# Only run on a specific event. Useful for debugging
+
+# NaN b-tagging discriminant for a jet
+# input file: /store/mc/RunIISpring15MiniAODv2/TTTo2L2Nu_13TeV-powheg/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/60000/88E6468A-C56D-E511-B6C8-001E67248142.root
+#process.source.eventsToProcess = cms.untracked.VEventRange(
+        #'1:25002:4987798',
+        #)
+
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))


### PR DESCRIPTION
It seems that b-tag discriminant can be `NaN`. This PR protects against such cases by setting the discriminant value to -10.
