### PR TITLE
Adding dca

### DIFF
--- a/interface/ElectronsProducer.h
+++ b/interface/ElectronsProducer.h
@@ -36,6 +36,7 @@ class ElectronsProducer: public LeptonsProducer<pat::Electron>, public Identifia
 
         BRANCH(dxy, std::vector<float>);
         BRANCH(dz, std::vector<float>);
+        BRANCH(dca, std::vector<float>);
 };
 
 #endif

--- a/interface/MuonsProducer.h
+++ b/interface/MuonsProducer.h
@@ -46,6 +46,7 @@ class MuonsProducer: public LeptonsProducer<pat::Muon>, public ScaleFactors {
 
         BRANCH(dxy, std::vector<float>);
         BRANCH(dz, std::vector<float>);
+        BRANCH(dca, std::vector<float>);
         rochcor2015 rmcor;
 };
 

--- a/src/ElectronsProducer.cc
+++ b/src/ElectronsProducer.cc
@@ -39,7 +39,7 @@ void ElectronsProducer::produce(edm::Event& event, const edm::EventSetup& eventS
         //     https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_15/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleDxyCut.cc#L64
         dxy.push_back(electron.gsfTrack()->dxy(primary_vertex.position()));
         dz.push_back(electron.gsfTrack()->dz(primary_vertex.position()));
-
+        dca.push_back(electron.dB(pat::Electron::PV3D)/electron.edB(pat::Electron::PV3D));
         ScaleFactors::store_scale_factors({static_cast<float>(fabs(electron.eta())), static_cast<float>(electron.pt())},event.isRealData());
     }
     Identifiable::clean();

--- a/src/MuonsProducer.cc
+++ b/src/MuonsProducer.cc
@@ -42,6 +42,7 @@ void MuonsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup
         //     https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_15/DataFormats/MuonReco/src/MuonSelectors.cc#L756
         dxy.push_back(muon.muonBestTrack()->dxy(primary_vertex.position()));
         dz.push_back(muon.muonBestTrack()->dz(primary_vertex.position()));
+        dca.push_back(muon.dB(pat::Muon::PV3D)/muon.edB(pat::Muon::PV3D));
         ScaleFactors::store_scale_factors({static_cast<float>(fabs(muon.eta())), static_cast<float>(muon.pt())},event.isRealData());
     }
 }


### PR DESCRIPTION
A new variable which record the 3D compatibility (expressed in terms of resolution) between the prompt leptons candidates and the PV. Typically, if fabs(dca)<5, i.e. if the distance is less than 5 times the resolution, the compatibility can be assumed. 
