### PR TITLE
[76X] Store absolute SF errors

### DIFF
--- a/data/ScaleFactors/BTagging_loose_bjets_mujets_CSVv2_25ns.json
+++ b/data/ScaleFactors/BTagging_loose_bjets_mujets_CSVv2_25ns.json
@@ -19,7 +19,7 @@
       1.0
     ]
   }, 
-  "absolute_errors": true, 
+  "error_type": "variated",
   "variable": "y", 
   "formula": true, 
   "data": [

--- a/data/ScaleFactors/BTagging_loose_cjets_mujets_CSVv2_25ns.json
+++ b/data/ScaleFactors/BTagging_loose_cjets_mujets_CSVv2_25ns.json
@@ -19,7 +19,7 @@
       1.0
     ]
   }, 
-  "absolute_errors": true, 
+  "error_type": "variated",
   "variable": "y", 
   "formula": true, 
   "data": [

--- a/data/ScaleFactors/BTagging_loose_lightjets_comb_CSVv2_25ns.json
+++ b/data/ScaleFactors/BTagging_loose_lightjets_comb_CSVv2_25ns.json
@@ -13,7 +13,7 @@
       1.0
     ]
   }, 
-  "absolute_errors": true, 
+  "error_type": "variated",
   "variable": "y", 
   "formula": true, 
   "data": [

--- a/data/ScaleFactors/BTagging_medium_bjets_mujets_CSVv2_25ns.json
+++ b/data/ScaleFactors/BTagging_medium_bjets_mujets_CSVv2_25ns.json
@@ -19,7 +19,7 @@
       1.0
     ]
   }, 
-  "absolute_errors": true, 
+  "error_type": "variated",
   "variable": "y", 
   "formula": true, 
   "data": [

--- a/data/ScaleFactors/BTagging_medium_cjets_mujets_CSVv2_25ns.json
+++ b/data/ScaleFactors/BTagging_medium_cjets_mujets_CSVv2_25ns.json
@@ -19,7 +19,7 @@
       1.0
     ]
   }, 
-  "absolute_errors": true, 
+  "error_type": "variated",
   "variable": "y", 
   "formula": true, 
   "data": [

--- a/data/ScaleFactors/BTagging_medium_lightjets_comb_CSVv2_25ns.json
+++ b/data/ScaleFactors/BTagging_medium_lightjets_comb_CSVv2_25ns.json
@@ -13,7 +13,7 @@
       1.0
     ]
   }, 
-  "absolute_errors": true, 
+  "error_type": "variated",
   "variable": "y", 
   "formula": true, 
   "data": [

--- a/data/ScaleFactors/BTagging_tight_bjets_mujets_CSVv2_25ns.json
+++ b/data/ScaleFactors/BTagging_tight_bjets_mujets_CSVv2_25ns.json
@@ -19,7 +19,7 @@
       1.0
     ]
   }, 
-  "absolute_errors": true, 
+  "error_type": "variated",
   "variable": "y", 
   "formula": true, 
   "data": [

--- a/data/ScaleFactors/BTagging_tight_cjets_mujets_CSVv2_25ns.json
+++ b/data/ScaleFactors/BTagging_tight_cjets_mujets_CSVv2_25ns.json
@@ -19,7 +19,7 @@
       1.0
     ]
   }, 
-  "absolute_errors": true, 
+  "error_type": "variated",
   "variable": "y", 
   "formula": true, 
   "data": [

--- a/data/ScaleFactors/BTagging_tight_lightjets_comb_CSVv2_25ns.json
+++ b/data/ScaleFactors/BTagging_tight_lightjets_comb_CSVv2_25ns.json
@@ -13,7 +13,7 @@
       1.0
     ]
   }, 
-  "absolute_errors": true, 
+  "error_type": "variated",
   "variable": "y", 
   "formula": true, 
   "data": [

--- a/data/ScaleFactors/Electron_sfLOOSE_id.json
+++ b/data/ScaleFactors/Electron_sfLOOSE_id.json
@@ -266,6 +266,7 @@
       ]
     }
   ], 
+  "error_type": "absolute",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/Electron_sfMEDIUM_id.json
+++ b/data/ScaleFactors/Electron_sfMEDIUM_id.json
@@ -265,7 +265,8 @@
         }
       ]
     }
-  ], 
+  ],
+  "error_type": "absolute",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/Electron_sfTIGHT_id.json
+++ b/data/ScaleFactors/Electron_sfTIGHT_id.json
@@ -266,6 +266,7 @@
       ]
     }
   ], 
+  "error_type": "absolute",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/Electron_sfVETO_id.json
+++ b/data/ScaleFactors/Electron_sfVETO_id.json
@@ -266,6 +266,7 @@
       ]
     }
   ], 
+  "error_type": "absolute",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/Mu17Mu8_SF.json
+++ b/data/ScaleFactors/Mu17Mu8_SF.json
@@ -177,6 +177,7 @@
       ]
     } 
   ], 
+  "error_type": "relative",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/Muon_LooseID_genTracks_id.json
+++ b/data/ScaleFactors/Muon_LooseID_genTracks_id.json
@@ -249,6 +249,7 @@
       ]
     }
   ], 
+  "error_type": "absolute",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/Muon_LooseRelIso_LooseID_iso.json
+++ b/data/ScaleFactors/Muon_LooseRelIso_LooseID_iso.json
@@ -249,6 +249,7 @@
       ]
     }
   ], 
+  "error_type": "absolute",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/Muon_LooseRelIso_MediumID_iso.json
+++ b/data/ScaleFactors/Muon_LooseRelIso_MediumID_iso.json
@@ -249,6 +249,7 @@
       ]
     }
   ], 
+  "error_type": "absolute",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/Muon_LooseRelIso_TightID_iso.json
+++ b/data/ScaleFactors/Muon_LooseRelIso_TightID_iso.json
@@ -249,6 +249,7 @@
       ]
     }
   ], 
+  "error_type": "absolute",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/Muon_MediumID_genTracks_id.json
+++ b/data/ScaleFactors/Muon_MediumID_genTracks_id.json
@@ -249,6 +249,7 @@
       ]
     }
   ], 
+  "error_type": "absolute",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/Muon_TightIDandIPCut_genTracks_id.json
+++ b/data/ScaleFactors/Muon_TightIDandIPCut_genTracks_id.json
@@ -249,6 +249,7 @@
       ]
     }
   ], 
+  "error_type": "absolute",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/Muon_TightRelIso_MediumID_iso.json
+++ b/data/ScaleFactors/Muon_TightRelIso_MediumID_iso.json
@@ -249,6 +249,7 @@
       ]
     }
   ], 
+  "error_type": "absolute",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/Muon_TightRelIso_TightID_iso.json
+++ b/data/ScaleFactors/Muon_TightRelIso_TightID_iso.json
@@ -249,6 +249,7 @@
       ]
     }
   ], 
+  "error_type": "absolute",
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/ScaleFactors/scalefactor_sample.json
+++ b/data/ScaleFactors/scalefactor_sample.json
@@ -4,7 +4,7 @@
         "x": [0, 1, 2],
         "y": [0, 10, 50, 1000]
     },
-    "absolute_errors": false,
+    "error_type": "absolute",
     "formula": false,
     "data": [
         {

--- a/src/ScaleFactorParser.cc
+++ b/src/ScaleFactorParser.cc
@@ -35,7 +35,18 @@ void ScaleFactorParser::parse_file(const std::string& file) {
         else
             throw edm::Exception(edm::errors::LogicError, "Unsupported variable: " + variable);
     }
-    m_scale_factor.absolute_errors = ptree.get<bool>("absolute_errors", false);
+
+    std::string error_type = ptree.get<std::string>("error_type");
+    std::transform(error_type.begin(), error_type.end(), error_type.begin(), ::tolower);
+
+    if (error_type == "absolute")
+        m_scale_factor.error_type = ScaleFactor::ErrorType::ABSOLUTE;
+    else if (error_type == "relative")
+        m_scale_factor.error_type = ScaleFactor::ErrorType::RELATIVE;
+    else if (error_type == "variated")
+        m_scale_factor.error_type = ScaleFactor::ErrorType::VARIATED;
+    else
+        throw std::runtime_error("Invalid error_type. Only 'absolute', 'relative' and 'variated' are supported");
 
     switch (dimension) {
         case 1:


### PR DESCRIPTION
Forward port of #118 

---

JSON file syntax has also been extended to support 3 types of errors.
Suppose we have E +/- ΔE. Errors can be defined in the JSON, via the
"error_type" parameter, as:
- "absolute" = ΔE
- "relative" = ΔE / E
- "variated" = E + ΔE or E - ΔE

All errors will be stored as "absolute" in the output tree
