### PR TITLE
[74X] Contain TTree memory usage

### DIFF
--- a/interface/Tools.h
+++ b/interface/Tools.h
@@ -29,4 +29,6 @@ namespace Tools {
     inline bool caseInsensitiveEquals(const std::string& a, const std::string& b) {
         return std::equal(a.begin(), a.end(), b.begin(), [](char a, char b) { return std::tolower(a) == std::tolower(b); });
     }
+
+    double process_mem_usage();
 };

--- a/src/Tools.cc
+++ b/src/Tools.cc
@@ -1,6 +1,8 @@
 #include <cp3_llbb/Framework/interface/Tools.h>
 #include <DataFormats/PatCandidates/interface/Jet.h>
 
+#include <fstream>
+
 namespace Tools {
     namespace Jets {
 
@@ -34,4 +36,40 @@ namespace Tools {
         }
 #pragma GCC diagnostic pop
     };
+
+    double process_mem_usage() {
+        using std::ios_base;
+        using std::ifstream;
+        using std::string;
+
+        double resident_set = 0.0;
+
+        // 'file' stat seems to give the most reliable results
+        //
+        ifstream stat_stream("/proc/self/stat",ios_base::in);
+
+        // dummy vars for leading entries in stat that we don't care about
+        //
+        string pid, comm, state, ppid, pgrp, session, tty_nr;
+        string tpgid, flags, minflt, cminflt, majflt, cmajflt;
+        string utime, stime, cutime, cstime, priority, nice;
+        string O, itrealvalue, starttime;
+
+        // the two fields we want
+        //
+        unsigned long vsize;
+        long rss;
+
+        stat_stream >> pid >> comm >> state >> ppid >> pgrp >> session >> tty_nr
+            >> tpgid >> flags >> minflt >> cminflt >> majflt >> cmajflt
+            >> utime >> stime >> cutime >> cstime >> priority >> nice
+            >> O >> itrealvalue >> starttime >> vsize >> rss; // don't care about the rest
+
+        stat_stream.close();
+
+        long page_size_kb = sysconf(_SC_PAGE_SIZE) / 1024; // in case x86-64 is configured to use 2MB pages
+        resident_set = rss * page_size_kb;
+
+        return resident_set / 1024;
+    }
 };


### PR DESCRIPTION
This is a fix to contain TTree excessive memory usage. The solution was to force the tree to flush after a small number of events. This number was tweaked by hand to stay under 1 GB of RAM after 10000 events using the HHAnalyzer (ie ~140 events).

This should prevent jobs of being killed when running with systematics.

I've also let my debugging code to show the memory usage in case it's one day useful. It's off by default but a define can bring it back.

cc @OlivierBondu 
