### PR TITLE
[74X] Add min / max values to JSON files

### DIFF
--- a/data/Efficiencies/Electron_HLT_Ele17_12Leg1_TightID.json
+++ b/data/Efficiencies/Electron_HLT_Ele17_12Leg1_TightID.json
@@ -1162,6 +1162,8 @@
       ]
     }
   ], 
+  "maximum": 1,
+  "minimum": 0,
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/Efficiencies/Electron_HLT_Ele17_12Leg2_TightID.json
+++ b/data/Efficiencies/Electron_HLT_Ele17_12Leg2_TightID.json
@@ -1162,6 +1162,8 @@
       ]
     }
   ], 
+  "maximum": 1,
+  "minimum": 0,
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/Efficiencies/Muon_TnP_DoubleIsoMu17Mu8_IsoMu17leg_Run2015D_25ns_PTvsETA_binBig_HWW_ID_M_ISO_T.json
+++ b/data/Efficiencies/Muon_TnP_DoubleIsoMu17Mu8_IsoMu17leg_Run2015D_25ns_PTvsETA_binBig_HWW_ID_M_ISO_T.json
@@ -3138,6 +3138,8 @@
       ]
     }
   ], 
+  "maximum": 1,
+  "minimum": 0,
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/Efficiencies/Muon_TnP_DoubleIsoMu17Mu8_IsoMu8leg_Run2015D_25ns_PTvsETA_binBig_HWW_ID_M_ISO_T.json
+++ b/data/Efficiencies/Muon_TnP_DoubleIsoMu17Mu8_IsoMu8leg_Run2015D_25ns_PTvsETA_binBig_HWW_ID_M_ISO_T.json
@@ -3138,6 +3138,8 @@
       ]
     }
   ], 
+  "maximum": 1,
+  "minimum": 0,
   "dimension": 2, 
   "binning": {
     "y": [

--- a/data/Efficiencies/Muon_TnP_DoubleIsoMu17Mu8_TkMu8leg_Run2015D_25ns_PTvsETA_binBig_HWW_ID_M_ISO_T.json
+++ b/data/Efficiencies/Muon_TnP_DoubleIsoMu17Mu8_TkMu8leg_Run2015D_25ns_PTvsETA_binBig_HWW_ID_M_ISO_T.json
@@ -3138,6 +3138,8 @@
       ]
     }
   ], 
+  "maximum": 1,
+  "minimum": 0,
   "dimension": 2, 
   "binning": {
     "y": [

--- a/interface/BTaggingScaleFactors.h
+++ b/interface/BTaggingScaleFactors.h
@@ -9,7 +9,7 @@
 #include <FWCore/Utilities/interface/EDMException.h>
 
 #include <cp3_llbb/Framework/interface/Histogram.h>
-#include <cp3_llbb/Framework/interface/ScaleFactor.h>
+#include <cp3_llbb/Framework/interface/BinnedValues.h>
 #include <cp3_llbb/TreeWrapper/interface/TreeWrapper.h>
 
 #include <boost/property_tree/ptree.hpp>
@@ -55,7 +55,7 @@ class BTaggingScaleFactors {
         ROOT::TreeGroup& m_tree;
 
         std::map<branch_key_type, std::vector<std::vector<float>>*> m_branches;
-        std::map<sf_key_type, ScaleFactor> m_scale_factors;
+        std::map<sf_key_type, BinnedValues> m_scale_factors;
 
         std::map<Algorithm, std::vector<std::string>> m_algos;
 

--- a/interface/BinnedValues.h
+++ b/interface/BinnedValues.h
@@ -5,13 +5,13 @@
 #include <memory>
 #include <TFormula.h>
 
-enum class Variation {
+enum Variation {
     Nominal = 0,
     Down = 1,
     Up = 2
 };
 
-struct ScaleFactor {
+struct BinnedValues {
 
     /**
      * Type of possible errors: Suppose we have E +- ΔE
@@ -25,9 +25,9 @@ struct ScaleFactor {
         VARIATED
     };
 
-    friend class ScaleFactorParser;
+    friend class BinnedValuesJSONParser;
 
-    ScaleFactor(ScaleFactor&& rhs) {
+    BinnedValues(BinnedValues&& rhs) {
         binned = std::move(rhs.binned);
         formula = std::move(rhs.formula);
         use_formula = rhs.use_formula;
@@ -35,7 +35,7 @@ struct ScaleFactor {
         formula_variable_index = rhs.formula_variable_index;
     }
 
-    ScaleFactor() = default;
+    BinnedValues() = default;
 
     private:
     template <typename _Value>
@@ -68,14 +68,17 @@ struct ScaleFactor {
     ErrorType error_type;
     size_t formula_variable_index = -1; // Only used in formula mode
 
+    float maximum;
+    float minimum;
+
     /**
      * Convert relative errors to absolute errors
      **/
     std::vector<float> relative_errors_to_absolute(const std::vector<float>& array) const {
         std::vector<float> result(3);
-        result[0] = array[0];
-        result[1] = array[0] * (1 + array[1]);
-        result[2] = array[0] * (1 - array[2]);
+        result[Nominal] = array[Nominal];
+        result[Up] = array[Nominal] * (1 + array[Up]);
+        result[Down] = array[Nominal] * (1 - array[Down]);
 
         return result;
     };
@@ -85,9 +88,9 @@ struct ScaleFactor {
      **/
     std::vector<float> variated_errors_to_absolute(const std::vector<float>& array) const {
         std::vector<float> result(3);
-        result[0] = array[0];
-        result[1] = std::abs(array[1] - array[0]);
-        result[2] = std::abs(array[0] - array[2]);
+        result[Nominal] = array[Nominal];
+        result[Up] = std::abs(array[Up] - array[Nominal]);
+        result[Down] = std::abs(array[Nominal] - array[Down]);
 
         return result;
     };
@@ -107,11 +110,25 @@ struct ScaleFactor {
         throw std::runtime_error("Invalid error type");
     }
 
+    /**
+     * Check that the up and down variation are
+     * still between the allowed range
+     **/
+    void clamp(std::vector<float>& array) const {
+        if ((array[Nominal] + array[Up]) > maximum) {
+            array[Up] = maximum - array[Nominal];
+        }
+
+        if ((array[Nominal] - array[Down]) < minimum) {
+            array[Down] = -(minimum - array[Nominal]);
+        }
+    }
+
     public:
     std::vector<float> get(const std::vector<float>& variables) const {
         static auto double_errors = [](std::vector<float>& values) {
-            values[1] *= 2;
-            values[2] *= 2;
+            values[Up] *= 2;
+            values[Down] *= 2;
         };
 
         bool outOfRange = false;
@@ -124,6 +141,8 @@ struct ScaleFactor {
 
             if (outOfRange)
                 double_errors(values);
+
+            clamp(values);
 
             return values;
         } else {
@@ -140,6 +159,8 @@ struct ScaleFactor {
 
             if (outOfRange)
                 double_errors(values);
+
+            clamp(values);
 
             return values;
         }

--- a/interface/BinnedValuesJSONParser.h
+++ b/interface/BinnedValuesJSONParser.h
@@ -8,7 +8,7 @@
 #include <DataFormats/Common/interface/ValueMap.h>
 
 #include <cp3_llbb/Framework/interface/Histogram.h>
-#include <cp3_llbb/Framework/interface/ScaleFactor.h>
+#include <cp3_llbb/Framework/interface/BinnedValues.h>
 
 #include <boost/property_tree/ptree.hpp>
 
@@ -16,15 +16,15 @@
 
 #include <TFormula.h>
 
-class ScaleFactorParser {
+class BinnedValuesJSONParser {
 
     public:
-        ScaleFactorParser(const std::string& file) {
+        BinnedValuesJSONParser(const std::string& file) {
             parse_file(file);
         }
 
-        virtual ScaleFactor&& get_scale_factor() final {
-            return std::move(m_scale_factor);
+        virtual BinnedValues&& get_values() final {
+            return std::move(m_values);
         }
 
     private:
@@ -48,15 +48,15 @@ class ScaleFactorParser {
             h.setBinErrorHigh(bin, error_high);
         }
 
-        void fillHistogram(ScaleFactor& sf, const std::vector<float>& bins, const float& value, const float& error_low, const float& error_high) {
-            fillHistogram(*sf.binned.get(), bins, value, error_low, error_high);
+        void fillHistogram(BinnedValues& val, const std::vector<float>& bins, const float& value, const float& error_low, const float& error_high) {
+            fillHistogram(*val.binned.get(), bins, value, error_low, error_high);
         }
 
-        void fillHistogram(ScaleFactor& sf, const std::vector<float>& bins, const std::string& value, const std::string& error_low, const std::string& error_high) {
+        void fillHistogram(BinnedValues& val, const std::vector<float>& bins, const std::string& value, const std::string& error_low, const std::string& error_high) {
             std::shared_ptr<TFormula> value_formula(new TFormula("", value.c_str()));
             std::shared_ptr<TFormula> error_low_formula(new TFormula("", error_low.c_str()));
             std::shared_ptr<TFormula> error_high_formula(new TFormula("", error_high.c_str()));
-            fillHistogram(*sf.formula.get(), bins, value_formula, error_low_formula, error_high_formula);
+            fillHistogram(*val.formula.get(), bins, value_formula, error_low_formula, error_high_formula);
         }
 
         template <typename _Content>
@@ -80,7 +80,7 @@ class ScaleFactorParser {
                                 _Content error_low = data_z.second.get<_Content>("error_low");
                                 _Content error_high = data_z.second.get<_Content>("error_high");
 
-                                fillHistogram(m_scale_factor, {mean_x, mean_y, mean_z}, value, error_low, error_high);
+                                fillHistogram(m_values, {mean_x, mean_y, mean_z}, value, error_low, error_high);
                             }
 
                         } else {
@@ -89,7 +89,7 @@ class ScaleFactorParser {
                             _Content error_low = data_y.second.get<_Content>("error_low");
                             _Content error_high = data_y.second.get<_Content>("error_high");
 
-                            fillHistogram(m_scale_factor, {mean_x, mean_y}, value, error_low, error_high);
+                            fillHistogram(m_values, {mean_x, mean_y}, value, error_low, error_high);
                         }
 
                     }
@@ -100,10 +100,10 @@ class ScaleFactorParser {
                     _Content error_low = data_x.second.get<_Content>("error_low");
                     _Content error_high = data_x.second.get<_Content>("error_high");
 
-                    fillHistogram(m_scale_factor, {mean_x}, value, error_low, error_high);
+                    fillHistogram(m_values, {mean_x}, value, error_low, error_high);
                 }
             }
         }
 
-        ScaleFactor m_scale_factor;
+        BinnedValues m_values;
 };

--- a/interface/ScaleFactors.h
+++ b/interface/ScaleFactors.h
@@ -8,7 +8,7 @@
 #include <DataFormats/Common/interface/ValueMap.h>
 
 #include <cp3_llbb/Framework/interface/Histogram.h>
-#include <cp3_llbb/Framework/interface/ScaleFactor.h>
+#include <cp3_llbb/Framework/interface/BinnedValues.h>
 #include <cp3_llbb/TreeWrapper/interface/TreeWrapper.h>
 
 #include <boost/property_tree/ptree.hpp>
@@ -34,5 +34,5 @@ class ScaleFactors {
         ROOT::TreeGroup& m_tree;
 
         std::map<std::string, std::vector<std::vector<float>>*> m_branches;
-        std::map<std::string, ScaleFactor> m_scale_factors;
+        std::map<std::string, BinnedValues> m_scale_factors;
 };

--- a/src/BTaggingScaleFactors.cc
+++ b/src/BTaggingScaleFactors.cc
@@ -1,5 +1,5 @@
 #include <cp3_llbb/Framework/interface/BTaggingScaleFactors.h>
-#include <cp3_llbb/Framework/interface/ScaleFactorParser.h>
+#include <cp3_llbb/Framework/interface/BinnedValuesJSONParser.h>
 
 #include <iostream>
 
@@ -47,8 +47,8 @@ void BTaggingScaleFactors::create_branches(const edm::ParameterSet& config) {
 
                 sf_key_type sf_key = std::make_tuple(algo, string_to_flavor(flavor), wp);
 
-                ScaleFactorParser parser(file);
-                m_scale_factors.emplace(sf_key, std::move(parser.get_scale_factor()));
+                BinnedValuesJSONParser parser(file);
+                m_scale_factors.emplace(sf_key, std::move(parser.get_values()));
             }
         }
 #ifdef SF_DEBUG

--- a/src/ScaleFactors.cc
+++ b/src/ScaleFactors.cc
@@ -1,5 +1,5 @@
 #include <cp3_llbb/Framework/interface/ScaleFactors.h>
-#include <cp3_llbb/Framework/interface/ScaleFactorParser.h>
+#include <cp3_llbb/Framework/interface/BinnedValuesJSONParser.h>
 
 #include <iostream>
 
@@ -12,9 +12,9 @@ void ScaleFactors::create_branches(const edm::ParameterSet& config) {
         for (const std::string& scale_factor: scale_factors_name) {
             create_branch(scale_factor, "sf_" + scale_factor);
 
-            ScaleFactorParser parser(scale_factors.getUntrackedParameter<edm::FileInPath>(scale_factor).fullPath());
+            BinnedValuesJSONParser parser(scale_factors.getUntrackedParameter<edm::FileInPath>(scale_factor).fullPath());
 
-            m_scale_factors.emplace(scale_factor, std::move(parser.get_scale_factor()));
+            m_scale_factors.emplace(scale_factor, std::move(parser.get_values()));
         }
     }
 


### PR DESCRIPTION
This allows efficiencies to be always between 0 and 1, no matter the errors.

Also, a huge error has been fixed: Up and Down errors were not always stored at the same position: for electrons and muons, it was 1: down, 2: up, but for b-tagged it was inverted. This is now fixed.

I also renamed classes to avoid using `ScaleFactor` to store efficiency, so you'll need to rename:
- `ScaleFactor` to `BinnedValues`
- `ScaleFactorParser` to `BinnedValuesJSONParser`
- and the function call of BinnedValuesJSONParser from `get_scale_factor` to `get_values`
