### PR TITLE
[74X] Reducing selected events before flushing the tree

### DIFF
--- a/src/Framework.cc
+++ b/src/Framework.cc
@@ -62,7 +62,7 @@ ExTreeMaker::ExTreeMaker(const edm::ParameterSet& iConfig):
         m_output->cd();
 
         TTree* tree = new TTree("t", "t");
-        tree->SetAutoFlush(140);
+        tree->SetAutoFlush(100);
         tree->SetMaxVirtualSize(500 * 1024 * 1024); // Allow max 500 MB for the tree
         m_wrapper.reset(new ROOT::TreeWrapper(tree));
 


### PR DESCRIPTION
I would check on [the current HH prod](http://dashb-cms-job.cern.ch/dashboard/templates/task-analysis/#user=Olivier+Bondu&refresh=60&table=Mains&p=1&records=100&activemenu=2&pattern=&task=&from=&till=&timerange=last3Days) if this has the intended effect before merging :)
