### PR TITLE
[74X] Contain memory usage, round 2

### DIFF
--- a/interface/Framework.h
+++ b/interface/Framework.h
@@ -55,7 +55,10 @@ class ExTreeMaker: public edm::EDProducer, ProducerGetter, AnalyzerGetter {
 
         std::string m_output_filename;
         std::unique_ptr<TFile> m_output;
+        TTree* m_raw_tree;
         std::unique_ptr<ROOT::TreeWrapper> m_wrapper;
+        size_t m_flush_size;
+        size_t m_filled_size = 0;
 
         std::unordered_map<std::string, std::shared_ptr<Framework::Filter>> m_filters;
 


### PR DESCRIPTION
This time it should be enough. Inside `TTree::Fill`, at the first basket flush, branch buffer are reallocated and the maximum size if the current size of the tree. Depending on when it occurs, it can be huge, and I see sometimes mem alloc of more than 2 GB ...

The solution is to bypass this mechanism by:
- Not calling `TTree::Fill` but directly `TBranch::Fill`
- Do the flushing manually. I've reused the value used in CMSSW

**Note: You'll need to update the `TreeWrapper` repository otherwise it won't builld!**
