### PR TITLE
[74X] Framework does some fitness

### DIFF
--- a/interface/CandidatesProducer.h
+++ b/interface/CandidatesProducer.h
@@ -48,13 +48,13 @@ class CandidatesProducer: public Framework::Producer {
     public:
         // Tree members
         std::vector<LorentzVector>& p4 = tree["p4"].write<std::vector<LorentzVector>>();
-        std::vector<float>& y = tree["y"].write<std::vector<float>>();
-        std::vector<int8_t>& charge = tree["charge"].write<std::vector<int8_t>>();
+        std::vector<float>& y = tree["y"].transient_write<std::vector<float>>();
+        std::vector<int8_t>& charge = tree["charge"].transient_write<std::vector<int8_t>>();
 
         std::vector<bool>& matched = tree["has_matched_gen_particle"].write<std::vector<bool>>();
         std::vector<LorentzVector>& gen_p4 = tree["gen_p4"].write<std::vector<LorentzVector>>();
-        std::vector<float>& gen_y = tree["gen_y"].write<std::vector<float>>();
-        std::vector<int8_t>& gen_charge = tree["gen_charge"].write<std::vector<int8_t>>();
+        std::vector<float>& gen_y = tree["gen_y"].transient_write<std::vector<float>>();
+        std::vector<int8_t>& gen_charge = tree["gen_charge"].transient_write<std::vector<int8_t>>();
 
 };
 

--- a/interface/GenParticlesProducer.h
+++ b/interface/GenParticlesProducer.h
@@ -43,12 +43,12 @@ class GenParticlesProducer: public Framework::Producer {
         std::vector<int16_t>& packed_status_flags = tree_packed["status_flags"].transient_write<std::vector<int16_t>>();
         std::vector<std::vector<uint16_t>>& packed_mothers_index = tree_packed["mothers_index"].transient_write<std::vector<std::vector<uint16_t>>>();
 
-        std::vector<LorentzVector>& pruned_p4 = tree_pruned["p4"].write<std::vector<LorentzVector>>();
-        std::vector<float>& pruned_y = tree_pruned["y"].write<std::vector<float>>();
-        std::vector<int16_t>& pruned_pdg_id = tree_pruned["pdg_id"].write<std::vector<int16_t>>();
-        std::vector<int8_t>& pruned_status = tree_pruned["status"].write<std::vector<int8_t>>();
-        std::vector<int16_t>& pruned_status_flags = tree_pruned["status_flags"].write<std::vector<int16_t>>();
-        std::vector<std::vector<uint16_t>>& pruned_mothers_index = tree_pruned["mothers_index"].write<std::vector<std::vector<uint16_t>>>();
+        std::vector<LorentzVector>& pruned_p4 = tree_pruned["p4"].transient_write<std::vector<LorentzVector>>();
+        std::vector<float>& pruned_y = tree_pruned["y"].transient_write<std::vector<float>>();
+        std::vector<int16_t>& pruned_pdg_id = tree_pruned["pdg_id"].transient_write<std::vector<int16_t>>();
+        std::vector<int8_t>& pruned_status = tree_pruned["status"].transient_write<std::vector<int8_t>>();
+        std::vector<int16_t>& pruned_status_flags = tree_pruned["status_flags"].transient_write<std::vector<int16_t>>();
+        std::vector<std::vector<uint16_t>>& pruned_mothers_index = tree_pruned["mothers_index"].transient_write<std::vector<std::vector<uint16_t>>>();
 };
 
 #endif

--- a/interface/JetsProducer.h
+++ b/interface/JetsProducer.h
@@ -103,19 +103,19 @@ class JetsProducer: public CandidatesProducer<pat::Jet>, public BTaggingScaleFac
         std::vector<int8_t>& hadronFlavor = tree["hadronFlavor"].write<std::vector<int8_t>>();
         std::vector<float>& jecFactor = tree["jecFactor"].write<std::vector<float>>();
         std::vector<float>& puJetID = tree["puJetID"].write<std::vector<float>>();
-        std::vector<float>& vtxMass = tree["vtxMass"].write<std::vector<float>>();
         // Variables needed for 74X b-jet energy regression as of January 26th 2016
-        BRANCH(neutralHadronEnergyFraction, std::vector<float>);
-        BRANCH(neutralEmEnergyFraction, std::vector<float>);
-        BRANCH(vtx3DVal, std::vector<float>);
-        BRANCH(vtx3DSig, std::vector<float>);
-        BRANCH(vtxPt, std::vector<float>);
-        BRANCH(vtxNtracks, std::vector<float>);
-        BRANCH(leptonPtRel, std::vector<float>);
-        BRANCH(leptonPt, std::vector<float>);
-        BRANCH(leptonDeltaR, std::vector<float>);
-        BRANCH(chargedMultiplicity, std::vector<float>);
-        BRANCH(leadTrackPt, std::vector<float>);
+        TRANSIENT_BRANCH(neutralHadronEnergyFraction, std::vector<float>);
+        TRANSIENT_BRANCH(neutralEmEnergyFraction, std::vector<float>);
+        TRANSIENT_BRANCH(vtxMass, std::vector<float>);
+        TRANSIENT_BRANCH(vtx3DVal, std::vector<float>);
+        TRANSIENT_BRANCH(vtx3DSig, std::vector<float>);
+        TRANSIENT_BRANCH(vtxPt, std::vector<float>);
+        TRANSIENT_BRANCH(vtxNtracks, std::vector<float>);
+        TRANSIENT_BRANCH(leptonPtRel, std::vector<float>);
+        TRANSIENT_BRANCH(leptonPt, std::vector<float>);
+        TRANSIENT_BRANCH(leptonDeltaR, std::vector<float>);
+        TRANSIENT_BRANCH(chargedMultiplicity, std::vector<float>);
+        TRANSIENT_BRANCH(leadTrackPt, std::vector<float>);
         BRANCH(regPt, std::vector<float>);
 
         BRANCH(passLooseID, std::vector<bool>);

--- a/interface/VerticesProducer.h
+++ b/interface/VerticesProducer.h
@@ -29,12 +29,12 @@ class VerticesProducer: public Framework::Producer {
     public:
         // Tree members
 
-        std::vector<float>& normalizedChi2 = tree["normalizedChi2"].write<std::vector<float>>();
-        std::vector<float>& ndof = tree["ndof"].write<std::vector<float>>();
-        std::vector<bool>& isFake = tree["isFake"].write<std::vector<bool>>();
-        std::vector<bool>& isValid = tree["isValid"].write<std::vector<bool>>();
-        std::vector<reco::Vertex::Point>& position = tree["position"].write<std::vector<reco::Vertex::Point>>();
-        std::vector<reco::Vertex::CovarianceMatrix>& covariance = tree["covariance"].write<std::vector<reco::Vertex::CovarianceMatrix>>();
+        std::vector<float>& normalizedChi2 = tree["normalizedChi2"].transient_write<std::vector<float>>();
+        std::vector<float>& ndof = tree["ndof"].transient_write<std::vector<float>>();
+        std::vector<bool>& isFake = tree["isFake"].transient_write<std::vector<bool>>();
+        std::vector<bool>& isValid = tree["isValid"].transient_write<std::vector<bool>>();
+        std::vector<reco::Vertex::Point>& position = tree["position"].transient_write<std::vector<reco::Vertex::Point>>();
+        std::vector<reco::Vertex::CovarianceMatrix>& covariance = tree["covariance"].transient_write<std::vector<reco::Vertex::CovarianceMatrix>>();
 };
 
 #endif

--- a/src/JetsProducer.cc
+++ b/src/JetsProducer.cc
@@ -19,52 +19,53 @@ void JetsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
         area.push_back(jet.jetArea());
         partonFlavor.push_back(jet.partonFlavour());
         hadronFlavor.push_back(jet.hadronFlavour());
-        // Variables needed for 74X b-jet energy regression as of January 26th 2016
-        neutralHadronEnergyFraction.push_back(jet.neutralHadronEnergyFraction());
-        neutralEmEnergyFraction.push_back(jet.neutralEmEnergyFraction());
-        vtx3DVal.push_back(jet.userFloat("vtx3DVal"));
-        vtx3DSig.push_back(jet.userFloat("vtx3DSig"));
-        float vtxPx = jet.userFloat("vtxPx");
-        float vtxPy = jet.userFloat("vtxPy");
-        float vtxPt_ = std::sqrt(std::pow(vtxPx,2) + std::pow(vtxPy,2));
-        vtxPt.push_back(vtxPt_);
-        vtxNtracks.push_back(jet.userFloat("vtxNtracks"));
-        // some loops needed to dig some information within the jet itself
-        std::vector<std::pair<float, int>> softLeptInJet; // pt, index
-        float leadTrackPt_ = 0.;
-        for (unsigned int idaughter = 0; idaughter < jet.numberOfDaughters(); idaughter++)
-        {
-            const reco::Candidate * daughter = jet.daughter(idaughter);
-            if (std::abs(daughter->pdgId()) == 11 || std::abs(daughter->pdgId()) == 13)
-                softLeptInJet.push_back( std::make_pair(daughter->pt(), idaughter) );
-            if (daughter->charge() != 0)
+        if (computeRegression) {
+            // Variables needed for 74X b-jet energy regression as of January 26th 2016
+            neutralHadronEnergyFraction.push_back(jet.neutralHadronEnergyFraction());
+            neutralEmEnergyFraction.push_back(jet.neutralEmEnergyFraction());
+            vtxMass.push_back(jet.userFloat("vtxMass"));
+            vtx3DVal.push_back(jet.userFloat("vtx3DVal"));
+            vtx3DSig.push_back(jet.userFloat("vtx3DSig"));
+            float vtxPx = jet.userFloat("vtxPx");
+            float vtxPy = jet.userFloat("vtxPy");
+            float vtxPt_ = std::sqrt(std::pow(vtxPx,2) + std::pow(vtxPy,2));
+            vtxPt.push_back(vtxPt_);
+            vtxNtracks.push_back(jet.userFloat("vtxNtracks"));
+            // some loops needed to dig some information within the jet itself
+            std::vector<std::pair<float, int>> softLeptInJet; // pt, index
+            float leadTrackPt_ = 0.;
+            for (unsigned int idaughter = 0; idaughter < jet.numberOfDaughters(); idaughter++)
             {
-                float leadTrackPt_tmp = daughter->pt();
-                if(leadTrackPt_tmp > leadTrackPt_)
-                    leadTrackPt_ = leadTrackPt_tmp;
+                const reco::Candidate * daughter = jet.daughter(idaughter);
+                if (std::abs(daughter->pdgId()) == 11 || std::abs(daughter->pdgId()) == 13)
+                    softLeptInJet.push_back( std::make_pair(daughter->pt(), idaughter) );
+                if (daughter->charge() != 0)
+                {
+                    float leadTrackPt_tmp = daughter->pt();
+                    if(leadTrackPt_tmp > leadTrackPt_)
+                        leadTrackPt_ = leadTrackPt_tmp;
+                }
             }
-        }
-        leadTrackPt.push_back(leadTrackPt_);
-        float leptonPtRel_ = -1.;
-        float leptonPt_ = -1.;
-        float leptonDeltaR_ = -1.;
-        int softLeptIdx_ = -1;
-        if (softLeptInJet.size() > 0)
-        {
-            std::sort(softLeptInJet.begin(), softLeptInJet.end());
-            softLeptIdx_ = softLeptInJet.back().second;
-            const reco::Candidate *daughter = jet.daughter(softLeptIdx_);
-            leptonPt_ = daughter->pt();
-            leptonPtRel_ = daughter->pt() / jet.pt();
-            leptonDeltaR_ = deltaR(*daughter, jet);
-        }
-        leptonPtRel.push_back(leptonPtRel_);
-        leptonPt.push_back(leptonPt_);
-        leptonDeltaR.push_back(leptonDeltaR_);
-        chargedMultiplicity.push_back(jet.chargedMultiplicity());
-        // The regression output itself
-        if (computeRegression)
-        {
+            leadTrackPt.push_back(leadTrackPt_);
+            float leptonPtRel_ = -1.;
+            float leptonPt_ = -1.;
+            float leptonDeltaR_ = -1.;
+            int softLeptIdx_ = -1;
+            if (softLeptInJet.size() > 0)
+            {
+                std::sort(softLeptInJet.begin(), softLeptInJet.end());
+                softLeptIdx_ = softLeptInJet.back().second;
+                const reco::Candidate *daughter = jet.daughter(softLeptIdx_);
+                leptonPt_ = daughter->pt();
+                leptonPtRel_ = daughter->pt() / jet.pt();
+                leptonDeltaR_ = deltaR(*daughter, jet);
+            }
+            leptonPtRel.push_back(leptonPtRel_);
+            leptonPt.push_back(leptonPt_);
+            leptonDeltaR.push_back(leptonDeltaR_);
+            chargedMultiplicity.push_back(jet.chargedMultiplicity());
+
+            // Regression itself
             Jet_pt = jet.pt();
             Jet_corr = jet.jecFactor("Uncorrected");
             rho = *rho_handle;
@@ -86,7 +87,6 @@ void JetsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
         } else {
             regPt.push_back(jet.pt());
         }
-//        std::cout << "computeRegression= " << computeRegression << "\tjet.pt()= " << jet.pt() << "\tregPt= " << regPt.back() << std::endl;
 
         passLooseID.push_back(Tools::Jets::passLooseId(jet));
         passTightID.push_back(Tools::Jets::passTightId(jet));
@@ -94,8 +94,6 @@ void JetsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
 
         if (jet.hasUserFloat("pileupJetId:fullDiscriminant"))
             puJetID.push_back(jet.userFloat("pileupJetId:fullDiscriminant"));
-
-        vtxMass.push_back(jet.userFloat("vtxMass"));
 
         for (auto& it: m_btag_discriminators) {
 


### PR DESCRIPTION
Output size of the tree starts to be an issue, so this PR removes some branches from the tree (they are still available on the analyzers side). Please check if there's a branch you'd like to keep on the output tree, or if there're you'd like to remove.

For 2799 events, output size is reduced to 12.3 MB from 17.5 MB (~-30%)
