### PR TITLE
[74X] Read JEC uncertainties from the GT by default

### DIFF
--- a/python/Framework.py
+++ b/python/Framework.py
@@ -234,6 +234,25 @@ class Framework(object):
 
         return self.producers.index(name)
 
+    def useJECDatabase(self, database):
+        """
+        JEC factors will be retrieved from the database instead of the Global Tag
+        """
+
+        self.ensureNotCreated()
+
+        # Read the JEC from a database
+        from cp3_llbb.Framework.Tools import load_jec_from_db
+        algo_sizes = {'ak': [4, 8]}
+        jet_types = ['pf', 'pfchs', 'puppi']
+        jet_algos = []
+        for k, v in algo_sizes.iteritems():
+            for s in v:
+                for j in jet_types:
+                    jet_algos.append(str(k.upper() + str(s) + j.upper().replace("CHS", "chs").replace("PUPPI", "PFPuppi")))
+
+        load_jec_from_db(self.process, database, jet_algos)
+
 
     def redoJEC(self, JECDatabase=None):
         """
@@ -252,16 +271,7 @@ class Framework(object):
 
         if JECDatabase:
             # Read the JEC from a database
-            from cp3_llbb.Framework.Tools import load_jec_from_db
-            algo_sizes = {'ak': [4, 8]}
-            jet_types = ['pf', 'pfchs', 'puppi']
-            jet_algos = []
-            for k, v in algo_sizes.iteritems():
-                for s in v:
-                    for j in jet_types:
-                        jet_algos.append(str(k.upper() + str(s) + j.upper().replace("CHS", "chs").replace("PUPPI", "PFPuppi")))
-
-            load_jec_from_db(self.process, JECDatabase, jet_algos)
+            self.useJECDatabase(JECDatabase)
 
         from cp3_llbb.Framework.Tools import setup_jets_mets_
         jet_collection, met_collection = setup_jets_mets_(self.process, self.isData)

--- a/python/Framework.py
+++ b/python/Framework.py
@@ -12,6 +12,7 @@ class Framework(object):
     def __init__(self, isData, era, **kwargs):
         self.__created = False
         self.__systematics = []
+        self.__systematicsOptions = {}
         self.__jec_done = False
         self.__jer_done = False
 
@@ -101,20 +102,22 @@ class Framework(object):
             if self.verbose:
                 print("")
 
-            systematics_options = {
+            default_systematics_options = {
                     'jec': {'jetCollection': self.__miniaod_jet_collection,
-                             'metCollection': self.__miniaod_met_collection,
-                             'uncertaintiesFile': 'cp3_llbb/Framework/data/Systematics/Summer15_25nsV6_MC_UncertaintySources_AK4PFchs.txt'},
+                        'metCollection': self.__miniaod_met_collection,
+                        'uncertaintiesFile': None},
                     'jer': {'jetCollection': self.__miniaod_jet_collection,
-                            'metCollection': self.__miniaod_met_collection,
-                            'genJetCollection': self.__miniaod_gen_jet_collection,
-                            'resolutionFile': self.__jer_resolution_file,
-                            'scaleFactorFile': self.__jer_scale_factor_file}
+                        'metCollection': self.__miniaod_met_collection,
+                        'genJetCollection': self.__miniaod_gen_jet_collection,
+                        'resolutionFile': self.__jer_resolution_file,
+                        'scaleFactorFile': self.__jer_scale_factor_file}
                     }
 
             systematics = {}
             for syst in self.__systematics:
-                systematics[syst] = systematics_options[syst]
+                user_systematics_options = self.__systematicsOptions[syst] if syst in self.__systematicsOptions else {}
+                systematics[syst] = copy.deepcopy(default_systematics_options[syst])
+                systematics[syst].update(user_systematics_options)
 
             print("")
             Systematics.doSystematics(self, systematics)
@@ -338,7 +341,7 @@ class Framework(object):
 
         self.__jer_done = True
 
-    def doSystematics(self, systematics):
+    def doSystematics(self, systematics, **kwargs):
         """
         Enable systematics
         """
@@ -349,6 +352,7 @@ class Framework(object):
             return
 
         self.__systematics = systematics
+        self.__systematicsOptions = kwargs
 
 
     #

--- a/python/Systematics.py
+++ b/python/Systematics.py
@@ -150,13 +150,19 @@ class JECSystematics(JetsSystematics):
 
         module = cms.EDProducer('ShiftedPATJetProducer',
                     src = cms.InputTag(self.jetCollection),
-                    jetCorrInputFileName = cms.FileInPath(self.uncertaintiesFile),
-                    jetCorrUncertaintyTag = cms.string('Total'),
                     addResidualJES = cms.bool(True),
                     jetCorrLabelUpToL3 = cms.InputTag('ak4PFCHSL1FastL2L3Corrector'),
                     jetCorrLabelUpToL3Res = cms.InputTag('ak4PFCHSL1FastL2L3ResidualCorrector'),
                     shiftBy = cms.double(shift)
                 )
+
+        tag = 'Total' if self.uncertaintiesFile else 'Uncertainty'
+        module.jetCorrUncertaintyTag = cms.string(tag)
+
+        if self.uncertaintiesFile:
+            module.jetCorrInputFileName = cms.FileInPath(self.uncertaintiesFile)
+        else:
+            module.jetCorrPayloadName = cms.string('AK4PFchs')
 
         return module
 

--- a/test/TestConfigurationData.py
+++ b/test/TestConfigurationData.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 
-framework = Framework.Framework(True, eras.Run2_50ns, globalTag='74X_dataRun2_v2', processName='RECO')
+framework = Framework.Framework(True, eras.Run2_50ns, globalTag='74X_dataRun2_reMiniAOD_v2', processName='RECO')
 
 framework.addAnalyzer('dilepton', cms.PSet(
         type = cms.string('dilepton_analyzer'),

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 
-framework = Framework.Framework(False, eras.Run2_25ns, globalTag='74X_mcRun2_asymptotic_v2')
+framework = Framework.Framework(False, eras.Run2_25ns, globalTag='74X_mcRun2_asymptotic_v5')
 
 framework.addAnalyzer('dilepton', cms.PSet(
     type = cms.string('dilepton_analyzer'),

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -33,23 +33,22 @@ framework.addAnalyzer('test', cms.PSet(
 
 framework.removeProducer('fat_jets')
 
+# Load JEC from the specified database instead of the GT. Will also affect the JEC systematics
+#framework.useJECDatabase('Fall15_25nsV2_MC.db')
+
 #framework.redoJEC()
 framework.smearJets()
 
-framework.doSystematics(['jec', 'jer'])
+#framework.doSystematics(['jec', 'jer'])
 
 # Change the pt cut for testing if it propagates correctly
-framework.getProducer('jets').parameters.cut = 'pt > 50'
+#framework.getProducer('jets').parameters.cut = 'pt > 50'
 
 process = framework.create()
 
 process.source.fileNames = cms.untracked.vstring(
         '/store/mc/RunIISpring15MiniAODv2/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/00000/0014DC94-DC5C-E511-82FB-7845C4FC39F5.root'
         )
-
-print process.framework.producers.jets.parameters.cut
-print process.framework.producers.jets_jecup.parameters.cut
-print process.framework.producers.jets_jecdown.parameters.cut
 
 # Only run on a specific event. Useful for debugging
 


### PR DESCRIPTION
Previously, JEC uncertainties were read from a text files, stored inside the `data` folder. The issue here is that we'll probably forget about it and fail to update this text file when new uncertainties are available.

This PR change the way uncertainties are retrieved. Now, the default is to use the Global Tag by default, but the user still have the choice to read a text files.

I've also made easier to tell the framework you want to load the JEC from a database instead of a Global Tag. There's a new method in the `Framework` class named `useJECDatabase`:

``` python
framework.useJECDatabase('Fall15_25nsV2_MC.db')
```

This affect both the JEC and the JEC uncertainties
