### PR TITLE
[74X] Protect against corrupted scale weights

### DIFF
--- a/src/EventProducer.cc
+++ b/src/EventProducer.cc
@@ -327,6 +327,10 @@ void EventProducer::produce(edm::Event& event_, const edm::EventSetup& eventSetu
         // Scale variations
         for (auto& m: m_scale_variations_matching) {
             float weight = lhe_info->weights()[m.second].wgt / lhe_weight_nominal_weight;
+            if ((weight < 0.1) || (weight > 10.)) {
+                std::cout << "Corrupted scale weight #" << scale_weights.size() << std::endl;
+                weight = 1.;
+            }
             scale_weights.push_back(weight);
         }
 


### PR DESCRIPTION
This PR sounds familiar... but this time for scale weights, not PDF weights. For some events, scale weights are 0, very small (e-28) or even infinite... This adds a protection against arbitrary large values of weights (greater than 10 or smaller than 0.1).

The first commits fixes the parsing of PDF set for some Powheg samples. The code now use regex instead of trying to parse the string itself.
