### PR TITLE
Store pointers to selected electrons

### DIFF
--- a/interface/ElectronsProducer.h
+++ b/interface/ElectronsProducer.h
@@ -41,6 +41,8 @@ class ElectronsProducer: public LeptonsProducer<pat::Electron>, public Identifia
         BRANCH(ecalPFClusterIso, std::vector<float>);
         BRANCH(hcalPFClusterIso, std::vector<float>);
         BRANCH(trackIso, std::vector<float>);
+
+        std::vector<edm::Ref<std::vector<pat::Electron>>> products;
 };
 
 #endif

--- a/src/ElectronsProducer.cc
+++ b/src/ElectronsProducer.cc
@@ -17,6 +17,8 @@ void ElectronsProducer::produce(edm::Event& event, const edm::EventSetup& eventS
 
     double rho = *rho_handle;
 
+    products.clear();
+
     size_t index = 0;
     for (const auto& electron: *electrons) {
         if (! pass_cut(electron)) {
@@ -32,6 +34,7 @@ void ElectronsProducer::produce(edm::Event& event, const edm::EventSetup& eventS
 
         const pat::ElectronRef electronRef(electrons, index++);
         Identifiable::produce_id(electronRef);
+        products.push_back(electronRef);
 
         isEB.push_back(electron.isEB());
         isEE.push_back(electron.isEE());


### PR DESCRIPTION
Useful to grab some information later from the object
without having to store them in the producer

TODO: Do the same for all others producers

Note: this is already used in https://github.com/cp3-llbb/HHAnalysis/pull/110