### PR TITLE
Add support for electron regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ pushd KaMuCa
 git checkout 2ad38daae37a41a9c07f482e95f2455e3eb915b0
 popd
 
+# Electron regression
+git cms-merge-topic rafaellopesdesa:Regression80XEgammaAnalysis
+
 scram b -j 4
 
 # Add the area containing the MVA weights (from cms-data, to appear in “external”).

--- a/bootstrap_jenkins.sh
+++ b/bootstrap_jenkins.sh
@@ -4,6 +4,8 @@
 # Current working dir is $CMSSW_BASE/src
 
 git cms-merge-topic ikrav:egm_id_80X_v2
+git cms-merge-topic rafaellopesdesa:Regression80XEgammaAnalysis
+
 git clone -o upstream https://github.com/bachtis/analysis.git -b KaMuCa_V4 KaMuCa 
 pushd KaMuCa
 git checkout 2ad38daae37a41a9c07f482e95f2455e3eb915b0

--- a/interface/DileptonAnalyzer.h
+++ b/interface/DileptonAnalyzer.h
@@ -18,8 +18,8 @@ class DileptonAnalyzer: public Framework::Analyzer {
                 m_muons_wp = string_to_wp(config.getUntrackedParameter<std::string>("muons_wp", "loose"));
                 m_electrons_wp = string_to_wp(config.getUntrackedParameter<std::string>("electrons_wp", "loose"));
 
-                m_electron_loose_wp_name = config.getUntrackedParameter<std::string>("electrons_loose_wp_name", "cutBasedElectronID-Spring15-25ns-V1-standalone-loose");
-                m_electron_tight_wp_name = config.getUntrackedParameter<std::string>("electrons_tight_wp_name", "cutBasedElectronID-Spring15-25ns-V1-standalone-tight");
+                m_electron_loose_wp_name = config.getUntrackedParameter<std::string>("electrons_loose_wp_name", "cutBasedElectronID-Summer16-80X-V1-loose");
+                m_electron_tight_wp_name = config.getUntrackedParameter<std::string>("electrons_tight_wp_name", "cutBasedElectronID-Summer16-80X-V1-tight");
         }
 
         virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const AnalyzersManager&, const CategoryManager&) override;

--- a/test/TestConfigurationData.py
+++ b/test/TestConfigurationData.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 
-framework = Framework.Framework(True, eras.Run2_25ns, globalTag='80X_dataRun2_Prompt_ICHEP16JEC_v0', processName='RECO')
+framework = Framework.Framework(True, eras.Run2_25ns, globalTag='80X_dataRun2_2016SeptRepro_v6', processName='RECO')
 
 framework.addAnalyzer('dilepton', cms.PSet(
         type = cms.string('dilepton_analyzer'),
@@ -26,12 +26,15 @@ framework.addAnalyzer('test', cms.PSet(
         enable = cms.bool(True)
         ))
 
+framework.applyElectronRegression()
+
 framework.doSystematics(['jec', 'jer'])
     
 process = framework.create()
 
 process.source.fileNames = cms.untracked.vstring(
-        '/store/data/Run2016B/DoubleMuon/MINIAOD/PromptReco-v2/000/273/158/00000/A6AC80E5-121A-E611-A689-02163E01439E.root'
+        '/store/data/Run2016H/DoubleEG/MINIAOD/PromptReco-v3/000/284/036/00000/1878DF24-619F-E611-A962-02163E0146C8.root'
+        # '/store/data/Run2016B/DoubleMuon/MINIAOD/PromptReco-v2/000/273/158/00000/A6AC80E5-121A-E611-A689-02163E01439E.root'
         )
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 
-framework = Framework.Framework(False, eras.Run2_25ns, globalTag='80X_mcRun2_asymptotic_2016_miniAODv2_v1')
+framework = Framework.Framework(False, eras.Run2_25ns, globalTag='80X_mcRun2_asymptotic_2016_TrancheIV_v7')
 
 framework.addAnalyzer('dilepton', cms.PSet(
     type = cms.string('dilepton_analyzer'),
@@ -34,20 +34,22 @@ framework.addAnalyzer('test', cms.PSet(
 framework.removeProducer('fat_jets')
 
 # Load JEC from the specified database instead of the GT. Will also affect the JEC systematics
-#framework.useJECDatabase('Fall15_25nsV2_MC.db')
+# framework.useJECDatabase('Fall15_25nsV2_MC.db')
 
-#framework.redoJEC()
-framework.smearJets()
+# framework.redoJEC()
+# framework.smearJets()
 # framework.applyMuonCorrection("kamuca")
+# framework.applyElectronRegression()
 
-#framework.doSystematics(['jec', 'jer'])
+# framework.doSystematics(['jec', 'jer'])
 
 # Change the pt cut for testing if it propagates correctly
-#framework.getProducer('jets').parameters.cut = 'pt > 50'
+# framework.getProducer('jets').parameters.cut = 'pt > 50'
 
 process = framework.create()
 
 process.source.fileNames = cms.untracked.vstring(
+        # '/store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-herwigpp_30M/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/043B3BC8-8BB7-E611-8CCE-0090FAA573E0.root'
         '/store/mc/RunIISpring16MiniAODv2/TTTo2L2Nu_13TeV-powheg/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/60000/022B4AD3-7A1B-E611-812B-28924A33B9AA.root'
         )
 
@@ -59,4 +61,4 @@ process.source.fileNames = cms.untracked.vstring(
         #'1:25002:4987798',
         #)
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(400))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(4000))


### PR DESCRIPTION
This PR adds support for electron regression in the framework. Simply call `framework.applyElectronRegression()` to enable it.

See this twiki page for more information: https://twiki.cern.ch/twiki/bin/view/CMS/EGMRegression

Some validation:
![mll_with_regression](https://cloud.githubusercontent.com/assets/386274/21229252/41735294-c2e1-11e6-969e-754630d66c24.png)
M_ll distribution for loose electrons, with regression (red) and without (blue)
