### PR TITLE
Reject fake muons

### DIFF
--- a/CMSSW.release
+++ b/CMSSW.release
@@ -1,1 +1,1 @@
-CMSSW_8_0_24_patch1
+CMSSW_8_0_25

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Common framework for all cp3-llbb analyses
 
 ## CMSSW release
 
-**CMSSW 8.0.24 patch 1**
+**CMSSW 8.0.25**
 
 ## First time setup instructions
 
@@ -18,8 +18,8 @@ source /nfs/soft/grid/ui_sl6/setup/grid-env.sh
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 
 export SCRAM_ARCH=slc6_amd64_gcc530
-cmsrel CMSSW_8_0_24_patch1
-cd CMSSW_8_0_24_patch1/src
+cmsrel CMSSW_8_0_25
+cd CMSSW_8_0_25/src
 cmsenv
 
 git cms-init
@@ -39,6 +39,9 @@ popd
 
 # Electron regression
 git cms-merge-topic rafaellopesdesa:Regression80XEgammaAnalysis
+
+# Fake-muon filter
+git cms-merge-topic gpetruc:badMuonFilters_80X_v2
 
 scram b -j 4
 

--- a/bootstrap_jenkins.sh
+++ b/bootstrap_jenkins.sh
@@ -5,6 +5,7 @@
 
 git cms-merge-topic ikrav:egm_id_80X_v2
 git cms-merge-topic rafaellopesdesa:Regression80XEgammaAnalysis
+git cms-merge-topic gpetruc:badMuonFilters_80X_v2
 
 git clone -o upstream https://github.com/bachtis/analysis.git -b KaMuCa_V4 KaMuCa 
 pushd KaMuCa

--- a/test/TestConfigurationData.py
+++ b/test/TestConfigurationData.py
@@ -33,8 +33,7 @@ framework.doSystematics(['jec', 'jer'])
 process = framework.create()
 
 process.source.fileNames = cms.untracked.vstring(
-        '/store/data/Run2016H/DoubleEG/MINIAOD/PromptReco-v3/000/284/036/00000/1878DF24-619F-E611-A962-02163E0146C8.root'
-        # '/store/data/Run2016B/DoubleMuon/MINIAOD/PromptReco-v2/000/273/158/00000/A6AC80E5-121A-E611-A689-02163E01439E.root'
+        '/store/data/Run2016F/DoubleMuon/MINIAOD/23Sep2016-v1/50000/040EDEBA-0490-E611-A424-008CFA110C68.root'
         )
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))


### PR DESCRIPTION
This PR adds support for the newly introduced fake muon filter. Unfortunatly, it requires to bump the release to 8.0.25... 

Implementation is straightforward: the filter is run first, and reject all the events where there's bad muons. I ran over 1000 events on DoubleMuon, run F, and 44 events were rejected. 