### PR TITLE
Protect against corrected PDF or scale weights

### DIFF
--- a/interface/EventProducer.h
+++ b/interface/EventProducer.h
@@ -12,7 +12,10 @@
 #include <map>
 
 // Uncomment to debug PDF uncertainties
-// #define DEBUG_PDF
+//#define DEBUG_PDF
+ 
+// Uncomment to debug PDF uncertainties (reduced output)
+//#define DEBUG_PDF_LIGHT
 
 // If uncommented, LHE weights for LO samples will be read from the LHE file, otherwise, they will be computed directly using LHAPDF.
 #define USE_LHE_WEIGHTS_FOR_LO


### PR DESCRIPTION
Latest episode of the endless story of corrupted PDF and scale weights.

On some samples, PDF and / or scale weights, coming directly from the
LHE, are corrupted (either 0, NaN, Inf, or very small / big). This PR tries to catch such weights, by checking if the value is < 0.01 or > 100. This should be more than enough for a regular weight, and will prevent propagation of inf or NaN to the sum of weights.