### PR TITLE
updating egamma regression to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ git checkout 2ad38daae37a41a9c07f482e95f2455e3eb915b0
 popd
 
 # Electron regression
-git cms-merge-topic rafaellopesdesa:Regression80XEgammaAnalysis
+# https://twiki.cern.ch/twiki/bin/view/CMS/EGMRegression
+git cms-merge-topic rafaellopesdesa:Regression80XEgammaAnalysis_v2
 
 # Fake-muon filter
 git cms-merge-topic gpetruc:badMuonFilters_80X_v2

--- a/bootstrap_jenkins.sh
+++ b/bootstrap_jenkins.sh
@@ -4,7 +4,7 @@
 # Current working dir is $CMSSW_BASE/src
 
 git cms-merge-topic ikrav:egm_id_80X_v2
-git cms-merge-topic rafaellopesdesa:Regression80XEgammaAnalysis
+git cms-merge-topic rafaellopesdesa:Regression80XEgammaAnalysis_v2
 git cms-merge-topic gpetruc:badMuonFilters_80X_v2
 
 git clone -o upstream https://github.com/bachtis/analysis.git -b KaMuCa_V4 KaMuCa 


### PR DESCRIPTION
Thanks to @RemKamal for the notice!

If I read correctly [Framework.py#L433-L441](https://github.com/cp3-llbb/Framework/blob/CMSSW_8_0_6p/python/Framework.py#L433-L441) this should be the only update needed