### PR TITLE
Fix various crashed related to Rochester and Smearing

### DIFF
--- a/interface/CorrectedMuonProducerT.h
+++ b/interface/CorrectedMuonProducerT.h
@@ -88,6 +88,10 @@ namespace cp3 {
                         scale_factor = corrector->kScaleAndSmearMC(muon.charge(), muon.pt(), muon.eta(), muon.phi(), n_tracks, random_distribution(random_generator), random_distribution(random_generator), 0 /* set */, 0 /* param */);
                 }
 
+                if (std::isnan(scale_factor)) {
+                    scale_factor = 1.;
+                }
+
                 T corrected_muon = muon;
                 corrected_muon.setP4(muon.p4() * scale_factor);
 

--- a/python/Framework.py
+++ b/python/Framework.py
@@ -496,7 +496,7 @@ class Framework(object):
         # Remove when it's no longer needed (see twiki)
         self.process.selectedElectrons = cms.EDFilter("PATElectronSelector",
                 src = cms.InputTag(self.__miniaod_electron_collection),
-                cut = cms.string("pt > 5 && abs(eta) < 2.5")
+                cut = cms.string("pt > 5 && abs(superCluster.eta) < 2.5")
                 )
 
         self.process.slimmedElectronsSmeared = calibratedPatElectrons.clone(


### PR DESCRIPTION
See commits for more details. In summary:
  - Rochester SFs are sometimes NaN if the input muons is crazy (pt > 13 TeV, stuff like that which seems to exist in standard MiniAOD collections)
  - Electron smearing crash if eta > 2.5. Twiki asks to add a filter to keep only electrons with eta < 2.5, but looking into the code, it's actually supercluster eta which is used, not eta, and I found a case where eta < 2.5 but supercluster eta = 3.81 (I know...)

