### PR TITLE
Update electron regression recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ git cms-merge-topic shervin86:Moriond2017_JEC_energyScales
 # https://twiki.cern.ch/twiki/bin/view/CMS/EGMRegression
 git cms-merge-topic rafaellopesdesa:Regression80XEgammaAnalysis_v2
 
+# Fix outside training boundary bug
+# https://twiki.cern.ch/twiki/bin/view/CMS/EGMRegression#TrainingBoundary
+# Cherry-pick the commits to avoid bumping CMSSW version to 8.0.26
+git remote add rafaellopesdesa https://github.com/rafaellopesdesa/cmssw.git
+git fetch rafaellopesdesa RegressionCheckNegEnergy
+git cherry-pick 67da8f10d8fa125197734ccea701035dd1020bd7
+git cherry-pick 3aafeff0371a1d1eb3db9d95ef50c1a66da25690
+git remote remove rafaellopesdesa
+
 scram b -j 4
 
 # Add the area containing the MVA weights (from cms-data, to appear in “external”).

--- a/bootstrap_jenkins.sh
+++ b/bootstrap_jenkins.sh
@@ -8,6 +8,12 @@ git cms-merge-topic rafaellopesdesa:Regression80XEgammaAnalysis_v2
 git cms-merge-topic shervin86:Moriond2017_JEC_energyScales
 git cms-merge-topic gpetruc:badMuonFilters_80X_v2
 
+git remote add rafaellopesdesa https://github.com/rafaellopesdesa/cmssw.git
+git fetch rafaellopesdesa RegressionCheckNegEnergy
+git cherry-pick 67da8f10d8fa125197734ccea701035dd1020bd7
+git cherry-pick 3aafeff0371a1d1eb3db9d95ef50c1a66da25690
+git remote remove rafaellopesdesa
+
 git clone -o upstream https://github.com/bachtis/analysis.git -b KaMuCa_V4 KaMuCa 
 pushd KaMuCa
 git checkout 2ad38daae37a41a9c07f482e95f2455e3eb915b0


### PR DESCRIPTION
Fix for issue reported on hypernews: https://hypernews.cern.ch/HyperNews/CMS/get/egamma/1863.html

I cherry-picked the fix commits instead of a plain merge-topic because the upstream is based on something more recent than 8.0.25 and I don't want to upgrade right now :)