### PR TITLE
Add a way for users to control tree flushing

### DIFF
--- a/interface/Framework.h
+++ b/interface/Framework.h
@@ -59,6 +59,7 @@ class ExTreeMaker: public edm::EDProducer, ProducerGetter, AnalyzerGetter {
         std::unique_ptr<ROOT::TreeWrapper> m_wrapper;
         size_t m_flush_size;
         size_t m_filled_size = 0;
+        bool m_baskets_optimized = false;
 
         std::unordered_map<std::string, std::shared_ptr<Framework::Filter>> m_filters;
 


### PR DESCRIPTION
This PR adds two new options in the configuration file to control the flushing of the output tree. It can helps for reducing the memory pressure to increase the flushing operations (by decreasing the memory needed to trigger a flush). The default is still set to 15 MB but it can now be override by the users:

```
process.framework.treeFlushSize = cms.untracked.uint64(5 * 1024 * 1024)
```

I also added a missing call to `OptimizeBackets` to mimic what is done in the `TTree::Fill` method. It should also helps to better optimize the memory usage.
