### PR TITLE
Ensure references are unique when creating a conditional branch

### DIFF
--- a/interface/Types.h
+++ b/interface/Types.h
@@ -15,8 +15,7 @@ namespace Framework {
         if (condition) {
             return tree[branch_name].write<T>();
         } else {
-            static T foo;
-            return foo;
+            return tree[branch_name].transient_write<T>();
         }
     }
 }


### PR DESCRIPTION
Currently, all the conditional branches of the same type shares the same memory space (ie, the same static variable). This leads to branch content overwritten by other branches of the same type, and can be disastrous if one perform some check based on the content of the variable.

This PR removes this limitation by ensure every branches have its own memory space.