### PR TITLE
Merge all option parsing into CmdLine

### DIFF
--- a/python/CmdLine.py
+++ b/python/CmdLine.py
@@ -9,34 +9,39 @@ class CmdLine(object):
         - 'runOnData': 1 if running on data, 0 otherwise
         - 'hltProcessName': the process name used when running the HLT
 
-    Can be customized from a config file (or better, subclass) using
-    changeDefaults(option=value, ...) and override(option=value, ...),
-    depending on whether the given value should be used is none is passed
-    on the command line, or if it should be used regardless of that.
+    Can be customized from a config file (or better, subclass) by passing
+    an override and/or a new default options dictionary to the constructor,
+    or by calling override(option=value, ...) and
+    changeDefaults(option=value, ...) directly, depending on depending on
+    whether the given value should be used is none is passed on the command
+    line, or if it should be used regardless of that.
     Options can be added using options.register.
     The registerOptions method (called from the constructor) can be
     overridden by subclasses, e.g.
     >>> from cp3_llbb.Framework.CmdLine import CmdLine
     >>> class MyCmdLine(CmdLine):
-    >>>     def __init__(self):
-    >>>         super(MyCmdLine, self).__init__()
+    >>>     def __init__(self, override=None, defaults=None):
+    >>>         super(MyCmdLine, self).__init__(override=override, defaults=defaults)
     >>>     def registerOptions(self):
     >>>         super(MyCmdLine, self).registerOptions()
     >>>         self.options.register(...) ## see FWCore.ParameterSet.VarParsing
+    >>>         ## optional (if it makes sense to do this at the class level)
     >>>         self.changeDefaults(option=value, ...)
     >>>         self.override(option=value, ...)
     >>>
-    >>> options = MyCmdLine()
+    >>> options = MyCmdLine(defaults=dict(era="2016"))
     >>> isData = options.runOnData ## triggers parsing of options
 
     Note: parsing of the arguments happens as soon as an option is accessed,
     so no more changes can be made after that.
     """
-    def __init__(self, override=None):
+    def __init__(self, override=None, defaults=None):
         self._overridden = override if override is not None else dict()
         self.options = VarParsing()
         self._parsed = False
         self.registerOptions()
+        if defaults is not None:
+            self.changeDefaults(**defaults)
 
     def override(self, **kwargs):
         """ Override value for given keys

--- a/test/TestConfigurationData.py
+++ b/test/TestConfigurationData.py
@@ -5,8 +5,7 @@ from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 from cp3_llbb.Framework.CmdLine import CmdLine
 
-options = CmdLine()
-options.changeDefaults(runOnData=1, era="25ns", globalTag='80X_dataRun2_2016SeptRepro_v7', process='RECO')
+options = CmdLine(defaults=dict(runOnData=1, era="25ns", globalTag='80X_dataRun2_2016SeptRepro_v7', process='RECO'))
 
 framework = Framework.Framework(options)
 

--- a/test/TestConfigurationData.py
+++ b/test/TestConfigurationData.py
@@ -3,8 +3,12 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
+from cp3_llbb.Framework.CmdLine import CmdLine
 
-framework = Framework.Framework(True, eras.Run2_25ns, globalTag='80X_dataRun2_2016SeptRepro_v7', processName='RECO')
+options = CmdLine()
+options.changeDefaults(runOnData=1, era="25ns", globalTag='80X_dataRun2_2016SeptRepro_v7', process='RECO')
+
+framework = Framework.Framework(options)
 
 framework.addAnalyzer('dilepton', cms.PSet(
         type = cms.string('dilepton_analyzer'),

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -5,8 +5,7 @@ from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 from cp3_llbb.Framework.CmdLine import CmdLine
 
-options = CmdLine()
-options.changeDefaults(runOnData=0, era="25ns",  globalTag='80X_mcRun2_asymptotic_2016_TrancheIV_v7')
+options = CmdLine(defaults=dict(runOnData=0, era="25ns", globalTag='80X_mcRun2_asymptotic_2016_TrancheIV_v7'))
 
 framework = Framework.Framework(options)
 

--- a/test/TestConfigurationMC.py
+++ b/test/TestConfigurationMC.py
@@ -3,8 +3,12 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
+from cp3_llbb.Framework.CmdLine import CmdLine
 
-framework = Framework.Framework(False, eras.Run2_25ns, globalTag='80X_mcRun2_asymptotic_2016_TrancheIV_v7')
+options = CmdLine()
+options.changeDefaults(runOnData=0, era="25ns",  globalTag='80X_mcRun2_asymptotic_2016_TrancheIV_v7')
+
+framework = Framework.Framework(options)
 
 framework.addAnalyzer('dilepton', cms.PSet(
     type = cms.string('dilepton_analyzer'),

--- a/test/unit_tests_data.py
+++ b/test/unit_tests_data.py
@@ -3,8 +3,12 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
+from cp3_llbb.Framework.CmdLine import CmdLine
 
-framework = Framework.Framework(True, eras.Run2_25ns, globalTag='80X_dataRun2_Prompt_ICHEP16JEC_v0', processName='RECO')
+options = CmdLine()
+options.changeDefaults(runOnData=1, era="25ns", globalTag='80X_dataRun2_Prompt_ICHEP16JEC_v0', process="RECO")
+
+framework = Framework.Framework(options)
 
 framework.redoJEC()
 

--- a/test/unit_tests_data.py
+++ b/test/unit_tests_data.py
@@ -5,8 +5,7 @@ from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 from cp3_llbb.Framework.CmdLine import CmdLine
 
-options = CmdLine()
-options.changeDefaults(runOnData=1, era="25ns", globalTag='80X_dataRun2_Prompt_ICHEP16JEC_v0', process="RECO")
+options = CmdLine(defaults=dict(runOnData=1, era="25ns", globalTag='80X_dataRun2_Prompt_ICHEP16JEC_v0', process="RECO"))
 
 framework = Framework.Framework(options)
 

--- a/test/unit_tests_mc.py
+++ b/test/unit_tests_mc.py
@@ -3,8 +3,12 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
+from cp3_llbb.Framework.CmdLine import CmdLine
 
-framework = Framework.Framework(False, eras.Run2_25ns, globalTag='80X_mcRun2_asymptotic_2016_miniAODv2_v1')
+options = CmdLine()
+options.changeDefaults(runOnData=0, era="25ns", globalTag='80X_mcRun2_asymptotic_2016_miniAODv2_v1')
+
+framework = Framework.Framework(options)
 framework.redoJEC()
 framework.smearJets()
 framework.applyMuonCorrection("kamuca")

--- a/test/unit_tests_mc.py
+++ b/test/unit_tests_mc.py
@@ -5,8 +5,7 @@ from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 from cp3_llbb.Framework.CmdLine import CmdLine
 
-options = CmdLine()
-options.changeDefaults(runOnData=0, era="25ns", globalTag='80X_mcRun2_asymptotic_2016_miniAODv2_v1')
+options = CmdLine(defaults=dict(runOnData=0, era="25ns", globalTag='80X_mcRun2_asymptotic_2016_miniAODv2_v1'))
 
 framework = Framework.Framework(options)
 framework.redoJEC()

--- a/test/unit_tests_mc_with_db.py
+++ b/test/unit_tests_mc_with_db.py
@@ -5,8 +5,7 @@ from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
 from cp3_llbb.Framework.CmdLine import CmdLine
 
-options = CmdLine()
-options.changeDefaults(runOnData=0, era="25ns", globalTag='80X_mcRun2_asymptotic_2016_miniAODv2_v1')
+options = CmdLine(defaults=dict(runOnData=0, era="25ns", globalTag='80X_mcRun2_asymptotic_2016_miniAODv2_v1'))
 
 framework = Framework.Framework(options)
 framework.redoJEC(JECDatabase='Spring16_25nsV1_MC.db')

--- a/test/unit_tests_mc_with_db.py
+++ b/test/unit_tests_mc_with_db.py
@@ -3,8 +3,12 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras
 from cp3_llbb.Framework import Framework
+from cp3_llbb.Framework.CmdLine import CmdLine
 
-framework = Framework.Framework(False, eras.Run2_25ns, globalTag='80X_mcRun2_asymptotic_2016_miniAODv2_v1')
+options = CmdLine()
+options.changeDefaults(runOnData=0, era="25ns", globalTag='80X_mcRun2_asymptotic_2016_miniAODv2_v1')
+
+framework = Framework.Framework(options)
 framework.redoJEC(JECDatabase='Spring16_25nsV1_MC.db')
 process = framework.create()
 


### PR DESCRIPTION
I noticed that the code to parse and validate command-line arguments and other options was a bit scattered (XXConfiguration.py, Framework/python/CmdLine.py and Framework/python/Framework.py).
This is a first attempt to put as much of that as possible in CmdLine - this has implications for Framework and the analysis configurations as well, and I may have missed important cases, so please have a look and give your opinion (not urgently). If we decide to go with this, we maybe should rename CmdLine into FrameworkOptions or something like that...
For an example of a configuration file using this, see https://github.com/pieterdavid/TTWAnalysis/blob/refactorCmdLine/test/TTWConfiguration.py (nothing spectacular, but the logic is a bit more explicit).
Last point: I took the opportunity to add the `Run2_2016` era as a valid option (even if that probably doesn't matter too much for our purpose at this point) - I'll move those changes to a separate PR and rebase once that's merged.