### PR TITLE
Merge cms-met:METRecipe_8020 only up to the changes compatible with CMSSW_8_0_26_patch2

### DIFF
--- a/bootstrap_jenkins.sh
+++ b/bootstrap_jenkins.sh
@@ -5,7 +5,11 @@
 
 git cms-merge-topic rafaellopesdesa:EgammaAnalysis80_EGMSmearer_Moriond17_23Jan
 git cms-merge-topic rafaellopesdesa:RegressionCheckNegEnergy
-git cms-merge-topic cms-met:METRecipe_8020 -u
+##git cms-merge-topic cms-met:METRecipe_8020 -u
+## -> 8_0_26patch2 version
+git remote add cms-met https://github.com/cms-met/cmssw
+git fetch cms-met METRecipe_8020
+git cms-merge-topic cms-met:83c1f5d9bfcbc669a0621cdd3c01893f47b268be -u
 
 git clone -o upstream https://github.com/bachtis/analysis.git -b KaMuCa_V4 KaMuCa 
 pushd KaMuCa


### PR DESCRIPTION
let's hope this fixes the failing jenkins build (probably best to specify or write down the specific commit for not explicitly versioned branches like this one, that should work as long as people don't force-push).
I don't see anything obviously incompatible in the more recent commits in that branch, it's probably through some newer/other packages these depend on