### PR TITLE
Add an "initial project setup" script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,59 +14,20 @@ Common framework for all cp3-llbb analyses
 ## First time setup instructions
 
 ```bash
+## the following two lines can be replaced by a call to the cms_env alias (see below)
 source /nfs/soft/grid/ui_sl6/setup/grid-env.sh
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 
-export SCRAM_ARCH=slc6_amd64_gcc530
-cmsrel CMSSW_8_0_30
-cd CMSSW_8_0_30/src
-cmsenv
-
-git cms-init
-
-# CP3-llbb framework itself
-git clone -o upstream git@github.com:blinkseb/TreeWrapper.git cp3_llbb/TreeWrapper
-git clone -b CMSSW_8_0_6p -o upstream git@github.com:cp3-llbb/Framework.git cp3_llbb/Framework
-
-# KalmanMuonCalibrator
-git clone -o upstream https://github.com/bachtis/analysis.git -b KaMuCa_V4 KaMuCa 
-pushd KaMuCa
-git checkout 2ad38daae37a41a9c07f482e95f2455e3eb915b0
-popd
-
-# Electron smearing consistent with regression
-git remote add cms-egamma https://github.com/cms-egamma/cmssw
-git fetch cms-egamma EGM_gain_v1
-git cms-merge-topic cms-egamma:f2ae5ef247d2544bdccd0460586b468eb35631c5 -u
-
-# Fix outside training boundary bug for EGM regression
-# https://twiki.cern.ch/twiki/bin/view/CMS/EGMRegression#TrainingBoundary
-git remote add rafaellopesdesa https://github.com/rafaellopesdesa/cmssw
-git fetch rafaellopesdesa RegressionCheckNegEnergy
-git cms-merge-topic rafaellopesdesa:3aafeff0371a1d1eb3db9d95ef50c1a66da25690 -u
-
-# MET filters
-git remote add cms-met https://github.com/cms-met/cmssw
-git fetch cms-met METRecipe_8020_for80Xintegration
-git cms-merge-topic cms-met:92f73cd3d16a9529585865a365de271e0535b68d -u
-
-scram b -j 4
-
-cd ${CMSSW_BASE}/src/EgammaAnalysis/ElectronTools/data
-git clone https://github.com/ECALELFS/ScalesSmearings.git
-cd ScalesSmearings
-git checkout fe4ce4355ef88e4fc0efaa6bad06c25e333fdb86 # corresponds to HEAD of branch Moriond17_gainSwitch_unc
-rm -rf .git
-
-cd ${CMSSW_BASE}/src/cp3_llbb/Framework
-source first_setup.sh
-cd ${CMSSW_BASE}/src
+wget https://raw.githubusercontent.com/cp3-llbb/Framework/CMSSW_8_0_6p/setup_project_with_framework.sh
+source setup_project_with_framework.sh
 ```
+
+The script will set up a CMSSW release area, apply the recipes in [``bootstrap_jenkins.sh``](https://github.com/cp3-llbb/Framework/blob/CMSSW_8_0_6p/bootstrap_jenkins.sh) and [``jenkins_postbuild.sh``](https://github.com/cp3-llbb/Framework/blob/CMSSW_8_0_6p/jenkins_postbuild.sh), perform an initial build, and add your and your colleagues' forks on GitHub as remotes for your ``Framework`` clone.
 
 If you are using ingrid, here's a useful alias to put in your ``bashrc`` file:
 
 ```bash
-alias cms_env="module purge; module load grid/grid_environment_sl6; module load crab/crab3; module load cms/cmssw;"
+alias cms_env="module purge; module load grid/grid_environment_sl6; module load crab/crab3; module load cms/cmssw; module load slurm/slurm_utils;"
 ```
 
 Then, just do ``cms_env`` to load all the CMSSW environment.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ wget https://raw.githubusercontent.com/cp3-llbb/Framework/CMSSW_8_0_6p/setup_pro
 source setup_project_with_framework.sh
 ```
 
-[This script](https://github.com/cp3-llbb/Framework/blob/CMSSW_8_0_6p/setup_project_with_framework.sh) will set up a CMSSW release area, apply the recipes in [``bootstrap_jenkins.sh``](https://github.com/cp3-llbb/Framework/blob/CMSSW_8_0_6p/bootstrap_jenkins.sh) and [``jenkins_postbuild.sh``](https://github.com/cp3-llbb/Framework/blob/CMSSW_8_0_6p/jenkins_postbuild.sh), perform an initial build, and add your and your colleagues' forks on GitHub as remotes for your ``Framework`` clone.
+[This script](setup_project_with_framework.sh) will set up a CMSSW release area, apply the recipes in [``bootstrap_jenkins.sh``](bootstrap_jenkins.sh) and [``jenkins_postbuild.sh``](jenkins_postbuild.sh), perform an initial build, and add your and your colleagues' forks on GitHub as remotes for your ``Framework`` clone.
 
 If you are using ingrid, here's a useful alias to put in your ``bashrc`` file:
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ source setup_project_with_framework.sh
 ```
 
 [This script](setup_project_with_framework.sh) will set up a CMSSW release area, apply the recipes in [``bootstrap_jenkins.sh``](bootstrap_jenkins.sh) and [``jenkins_postbuild.sh``](jenkins_postbuild.sh), perform an initial build, and add your and your colleagues' forks on GitHub as remotes for your ``Framework`` clone.
+Through the options `--branch NAME` and `--pr ID`, a project area for a different version can also be set created.
 
 If you are using ingrid, here's a useful alias to put in your ``bashrc`` file:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ source setup_project_with_framework.sh
 ```
 
 [This script](setup_project_with_framework.sh) will set up a CMSSW release area, apply the recipes in [``bootstrap_jenkins.sh``](bootstrap_jenkins.sh) and [``jenkins_postbuild.sh``](jenkins_postbuild.sh), perform an initial build, and add your and your colleagues' forks on GitHub as remotes for your ``Framework`` clone.
-Through the options `--branch NAME` and `--pr ID`, a project area for a different version can also be set created.
+Through the options `--branch NAME` and `--pr ID`, a project area for a different version can also be created.
 
 If you are using ingrid, here's a useful alias to put in your ``bashrc`` file:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ wget https://raw.githubusercontent.com/cp3-llbb/Framework/CMSSW_8_0_6p/setup_pro
 source setup_project_with_framework.sh
 ```
 
-The script will set up a CMSSW release area, apply the recipes in [``bootstrap_jenkins.sh``](https://github.com/cp3-llbb/Framework/blob/CMSSW_8_0_6p/bootstrap_jenkins.sh) and [``jenkins_postbuild.sh``](https://github.com/cp3-llbb/Framework/blob/CMSSW_8_0_6p/jenkins_postbuild.sh), perform an initial build, and add your and your colleagues' forks on GitHub as remotes for your ``Framework`` clone.
+[This script](https://github.com/cp3-llbb/Framework/blob/CMSSW_8_0_6p/setup_project_with_framework.sh) will set up a CMSSW release area, apply the recipes in [``bootstrap_jenkins.sh``](https://github.com/cp3-llbb/Framework/blob/CMSSW_8_0_6p/bootstrap_jenkins.sh) and [``jenkins_postbuild.sh``](https://github.com/cp3-llbb/Framework/blob/CMSSW_8_0_6p/jenkins_postbuild.sh), perform an initial build, and add your and your colleagues' forks on GitHub as remotes for your ``Framework`` clone.
 
 If you are using ingrid, here's a useful alias to put in your ``bashrc`` file:
 

--- a/setup_project_with_framework.sh
+++ b/setup_project_with_framework.sh
@@ -2,26 +2,17 @@
 
 startdir=$(pwd)
 
-cmssw_arch="slc6_amd64_gcc530" ## should be in sync with CMSSW.arch
-cmssw_version="CMSSW_8_0_30"   ## should be in sync with CMSSW.release
+tempdir=$(mktemp -d)
+fwkdir_tmp="${tempdir}/Framework"
+
+git clone -o upstream https://github.com/cp3-llbb/Framework "${fwkdir_tmp}"
+
+cmssw_arch=$(cat "${fwkdir_tmp}/CMSSW.arch")
+cmssw_version=$(cat "${fwkdir_tmp}/CMSSW.release")
 
 scramv1 -a "${cmssw_arch}" project CMSSW "${cmssw_version}"
 cd "${cmssw_version}"
 cmsenv
-
-git clone -o upstream https://github.com/cp3-llbb/Framework
-fwkdir_tmp="${CMSSW_BASE}/Framework"
-
-upstream_cmssw_arch=$(cat "Framework/CMSSW.arch")
-if [ "${upstream_cmssw_arch}" != "${cmssw_arch}" ]; then
-  echo "Platform mismatch with CMSSW.arch: ${upstream_cmssw_arch}, while set up with ${cmssw_arch}"
-  exit 1
-fi
-upstream_cmssw_version=$(cat "Framework/CMSSW.release")
-if [ "${upstream_cmssw_version}" != "${cmssw_version}" ]; then
-  echo "CMSSW version mismatch with CMSSW.release: ${upstream_cmssw_version}, while set up with ${cmssw_version}"
-  exit 1
-fi
 
 ## apply recipes
 cd "${CMSSW_BASE}/src"
@@ -30,10 +21,11 @@ cd "${CMSSW_BASE}/src"
 llbbdir="${CMSSW_BASE}/src/cp3_llbb"
 mkdir -p "${llbbdir}"
 mv "${fwkdir_tmp}" "${llbbdir}/"
+rmdir "${tempdir}"
 ## compile
-scram b -j4
+scram b -j7
 ## check out a few more
-. "${fwkpkg}/jenkins_postbuild.sh"
+. "${llbbdir}/Framework/jenkins_postbuild.sh"
 
 ## add git remotes
 cd "${llbbdir}/Framework"

--- a/setup_project_with_framework.sh
+++ b/setup_project_with_framework.sh
@@ -1,0 +1,47 @@
+#! /bin/sh
+
+startdir=$(pwd)
+
+cmssw_arch="slc6_amd64_gcc530" ## should be in sync with CMSSW.arch
+cmssw_version="CMSSW_8_0_30"   ## should be in sync with CMSSW.release
+
+scramv1 -a "${cmssw_arch}" project CMSSW "${cmssw_version}"
+cd "${cmssw_version}"
+cmsenv
+
+git clone -o upstream https://github.com/cp3-llbb/Framework
+fwkdir_tmp="${CMSSW_BASE}/Framework"
+
+upstream_cmssw_arch=$(cat "Framework/CMSSW.arch")
+if [ "${upstream_cmssw_arch}" != "${cmssw_arch}" ]; then
+  echo "Platform mismatch with CMSSW.arch: ${upstream_cmssw_arch}, while set up with ${cmssw_arch}"
+  exit 1
+fi
+upstream_cmssw_version=$(cat "Framework/CMSSW.release")
+if [ "${upstream_cmssw_version}" != "${cmssw_version}" ]; then
+  echo "CMSSW version mismatch with CMSSW.release: ${upstream_cmssw_version}, while set up with ${cmssw_version}"
+  exit 1
+fi
+
+## apply recipes
+cd "${CMSSW_BASE}/src"
+. "${fwkdir_tmp}/bootstrap_jenkins.sh"
+## move Framework to the right place
+llbbdir="${CMSSW_BASE}/src/cp3_llbb"
+mkdir -p "${llbbdir}"
+mv "${fwkdir_tmp}" "${llbbdir}/"
+## compile
+scram b -j4
+## check out a few more
+. "${fwkpkg}/jenkins_postbuild.sh"
+
+## add git remotes
+cd "${llbbdir}/Framework"
+. ./first_setup.sh
+
+cd "${startdir}"
+
+echo "================================================================================"
+echo "Set up project area for CMSSW version ${cmssw_version} in ${CMSSW_BASE}"
+echo "Next, cd ${CMSSW_BASE}/src; cmsenv, clone your analysis package, scram b, etc."
+echo "================================================================================"

--- a/setup_project_with_framework.sh
+++ b/setup_project_with_framework.sh
@@ -1,39 +1,109 @@
 #! /bin/sh
 
-startdir=$(pwd)
+# Bootstrap a CMSSW installation ready for a given framework version
+# Usage: source setup_project_with_framework.sh [-j N] [-o NAME] [ -b BRANCH || --pr PULLREQUESTID ]
 
-tempdir=$(mktemp -d)
-fwkdir_tmp="${tempdir}/Framework"
+FRAMEWORK_GITHUB=https://github.com/cp3-llbb/Framework
 
-git clone -o upstream https://github.com/cp3-llbb/Framework "${fwkdir_tmp}"
+# Default options
+CORE=4
+OUTPUT=""
 
-cmssw_arch=$(cat "${fwkdir_tmp}/CMSSW.arch")
-cmssw_version=$(cat "${fwkdir_tmp}/CMSSW.release")
+# Parse command line
+while [[ $# > 0 ]]
+do
+    key="$1"
 
-scramv1 -a "${cmssw_arch}" project CMSSW "${cmssw_version}"
-cd "${cmssw_version}"
-cmsenv
+    case $key in
+        -j|--core)
+            CORE="$2"
+            shift # past argument
+            ;;
+        -o|--output)
+            OUTPUT="$2"
+            shift # past argument
+            ;;
+        --pr)
+            GITREF="refs/pull/$2/head"
+            BRANCH="test-PR$2"
+            shift # past argument
+            ;;
+        -b|--branch)
+            BRANCH="$2"
+            shift # past argument
+            ;;
+        *)
+            # unknown option
+            echo "Usage: source setup_project_with_framework.sh [-j N] [-o NAME] [ -b BRANCH OR --pr PULLREQUESTID ]"
+            return 1
+            ;;
+    esac
+    shift # past argument or value
+done
 
-## apply recipes
-cd "${CMSSW_BASE}/src"
-. "${fwkdir_tmp}/bootstrap_jenkins.sh"
+## for messages
+if [[ "${BRANCH}" == "${GITREF}" ]]; then
+  GITDESCR="branch ${BRANCH}"
+else
+  GITDESCR="ref ${GITREF}:${BRANCH}"
+fi
+
+## Clone into a temporary directory, to make sure we get the correct architecture and release
+TEMPDIR=$(mktemp -d)
+FWKDIR_TMP="${TEMPDIR}/Framework"
+git clone -o upstream "${FRAMEWORK_GITHUB}" "${FWKDIR_TMP}"
+if [ -n "${GITREF}" ]; then
+  pushd "${FWKDIR_TMP}" &> /dev/null
+  ( git fetch upstream "${GITREF}:${BRANCH}" && git checkout "${BRANCH}" ) || ( echo "Problem checking out ${GITDESCR}" && exit 1 ) || return 1
+  popd &> /dev/null
+fi
+
+CMSSW_ARCH=$(cat "${FWKDIR_TMP}/CMSSW.arch")
+CMSSW_VERSION=$(cat "${FWKDIR_TMP}/CMSSW.release")
+DEPENDENCIES="${FWKDIR_TMP}/bootstrap_jenkins.sh"
+
+if [ -z "${OUTPUT}" ]; then
+  OUTPUT="${CMSSW_VERSION}"
+fi
+
+echo ""
+echo "Setting up ${CMSSW_VERSION} (${CMSSW_ARCH}) for Framework ${GITDESCR} into ${OUTPUT}"
+echo ""
+
+# Setup CMS env if necessary
+if [ -z "${CMS_PATH}" ]; then
+  source /cvmfs/cms.cern.ch/cmsset_default.sh
+fi
+
+scramv1 -a "${CMSSW_ARCH}" project -n "${OUTPUT}" CMSSW "${CMSSW_VERSION}"
+pushd "${OUTPUT}/src" &> /dev/null
+eval `scramv1 runtime -sh` # cmsenv
+
+## install dependencies
+source "${DEPENDENCIES}"
+
 ## move Framework to the right place
-llbbdir="${CMSSW_BASE}/src/cp3_llbb"
-mkdir -p "${llbbdir}"
-mv "${fwkdir_tmp}" "${llbbdir}/"
-rmdir "${tempdir}"
+mkdir -p "cp3_llbb"
+mv "${FWKDIR_TMP}" "cp3_llbb/"
+rmdir "${TEMPDIR}"
+
+# Configure git remotes
+pushd "cp3_llbb/Framework" &> /dev/null
+source first_setup.sh
+popd &> /dev/null
+
+echo ""
+echo "Bootstrapping done. Launching build using ${CORE} cores"
+echo ""
+
 ## compile
-scram b -j7
+scram b -j${CORE}
+
 ## check out a few more
-. "${llbbdir}/Framework/jenkins_postbuild.sh"
+source "cp3_llbb/Framework/jenkins_postbuild.sh"
 
-## add git remotes
-cd "${llbbdir}/Framework"
-. ./first_setup.sh
+OUTPUT_FULL=$(pwd) ## absolute path, for final message
+popd &> /dev/null
 
-cd "${startdir}"
-
-echo "================================================================================"
-echo "Set up project area for CMSSW version ${cmssw_version} in ${CMSSW_BASE}"
-echo "Next, cd ${CMSSW_BASE}/src; cmsenv, clone your analysis package, scram b, etc."
-echo "================================================================================"
+echo ""
+echo "All done, your project area in ${OUTPUT_FULL} is ready"


### PR DESCRIPTION
Mostly for convenience (and to prove to @alesaggio that it's not that hard to change CMSSW versions ;-) ).
This also removes the duplication between the jenkins scripts and README.md (which now simply links to those), which should make it a bit less work to update the recipes.