### PR TITLE
Checks on the order of Framework config method calls

### DIFF
--- a/python/Framework.py
+++ b/python/Framework.py
@@ -90,7 +90,7 @@ class Framework(object):
         process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(20))
         process.source = cms.Source("PoolSource")
 
-        self.configureFramework_()
+        self._configureFramework()
 
     @dep(before="create", performs="create", fallback=lambda self : self.process)
     def create(self):
@@ -527,8 +527,7 @@ class Framework(object):
 
             self.process.electronMVAValueMapProducer.srcMiniAOD = self.__miniaod_electron_collection
 
-    @dep(before="configure", performs="configure")
-    def configureFramework_(self):
+    def _configureFramework(self):
 
         from cp3_llbb.Framework import EventProducer
         from cp3_llbb.Framework import GenParticlesProducer

--- a/python/Framework.py
+++ b/python/Framework.py
@@ -5,6 +5,7 @@ from FWCore.ParameterSet.SequenceTypes import _SequenceCollection
 
 from Configuration.StandardSequences.Eras import eras
 
+from cp3_llbb.Framework.deptracker import deptracker as dep
 from cp3_llbb.Framework.Tools import change_process_name, change_input_tags_and_strings, StdStreamSilenter
 from cp3_llbb.Framework import Tools
 import cp3_llbb.Framework.Systematics as Systematics
@@ -12,11 +13,8 @@ import cp3_llbb.Framework.Systematics as Systematics
 class Framework(object):
 
     def __init__(self, options, verbose=True):
-        self.__created = False
         self.__systematics = []
         self.__systematicsOptions = {}
-        self.__jec_done = False
-        self.__jer_done = False
 
         # Default configuration
         self.__miniaod_jet_collection = 'slimmedJets'
@@ -29,10 +27,6 @@ class Framework(object):
 
         self.__jer_resolution_file = None
         self.__jer_scalefactor_file = None
-
-        self.__electron_regression_done = False
-        self.__electron_smearing_done = False
-        self.__muon_correction_done = False
 
         self.__kamuca_tag = 'DATA_80X_13TeV' if options.runOnData else 'MC_80X_13TeV'
         self.__rochester_input = 'cp3_llbb/Framework/data/Rochester/2016.v3/config.txt'
@@ -98,13 +92,11 @@ class Framework(object):
 
         self.configureFramework_()
 
+    @dep(before="create", performs="create", fallback=lambda self : self.process)
     def create(self):
         """
         Terminate the process configuration and return the final CMSSW process
         """
-
-        if self.__created:
-            return self.process
 
         self.configureElectronId_()
 
@@ -163,15 +155,13 @@ class Framework(object):
         self.process.framework.analyzers_scheduling = cms.untracked.vstring(self.analyzers)
         self.process.framework.producers_scheduling = cms.untracked.vstring(self.producers)
 
-        self.__created = True
         return self.process
 
+    @dep(before=("create", "correction"))
     def addAnalyzer(self, name, configuration, index=None):
         """
         Add an analyzer in the framework configuration with a given name and configuration
         """
-
-        self.ensureNotCreated()
 
         if name in self.analyzers:
             raise Exception('An analyzer named %r is already added to the configuration' % name)
@@ -181,12 +171,11 @@ class Framework(object):
         self.analyzers.insert(index, name)
         setattr(self.process.framework.analyzers, name, configuration)
 
+    @dep(before=("create", "correction"))
     def addProducer(self, name, configuration, index=None):
         """
         Add a producer in the framework configuration with a given name and configuration
         """
-
-        self.ensureNotCreated()
 
         if name in self.producers:
             raise Exception('A producer named %r is already added to the configuration' % name)
@@ -196,12 +185,11 @@ class Framework(object):
         self.producers.insert(index, name)
         setattr(self.process.framework.producers, name, configuration)
 
+    @dep(before=("create", "correction"))
     def getProducer(self, name):
         """
         Return a producer
         """
-
-        self.ensureNotCreated()
 
         if not name in self.producers:
             raise Exception('No producer named %r found in the configuration' % name)
@@ -209,12 +197,11 @@ class Framework(object):
         producer = getattr(self.process.framework.producers, name)
         return producer
 
+    @dep(before=("create", "correction"))
     def removeAnalyzer(self, name):
         """
         Remove an analyzer from the framework configuration
         """
-
-        self.ensureNotCreated()
 
         if not name in self.analyzers:
             raise Exception('Analyzer %r is not present in the framework configuration' % name)
@@ -222,12 +209,11 @@ class Framework(object):
         self.analyzers.remove(name)
         delattr(self.process.framework.analyzers, name)
 
+    @dep(before=("create", "correction"))
     def removeProducer(self, name):
         """
         Remove a producer from the framework configuration
         """
-
-        self.ensureNotCreated()
 
         if not name in self.producers:
             raise Exception('Producer %r is not present in the framework configuration' % name)
@@ -235,36 +221,33 @@ class Framework(object):
         self.producers.remove(name)
         delattr(self.process.framework.producers, name)
 
+    @dep(before=("create", "correction"))
     def getAnalyzerIndex(self, name):
         """
         Return the current index of an analyzer
         """
-
-        self.ensureNotCreated()
 
         if not name in self.analyzers:
             raise Exception('Analyzer %r is not present in the framework configuration' % name)
 
         return self.analyzers.index(name)
 
+    @dep(before=("create", "correction"))
     def getProducerIndex(self, name):
         """
         Return the current index of a producer
         """
-
-        self.ensureNotCreated()
 
         if not name in self.producers:
             raise Exception('Producer %r is not present in the framework configuration' % name)
 
         return self.producers.index(name)
 
+    @dep(before=("create", "correction"))
     def useJECDatabase(self, database):
         """
         JEC factors will be retrieved from the database instead of the Global Tag
         """
-
-        self.ensureNotCreated()
 
         # Read the JEC from a database
         from cp3_llbb.Framework.Tools import load_jec_from_db
@@ -278,6 +261,7 @@ class Framework(object):
 
         load_jec_from_db(self.process, database, jet_algos)
 
+    @dep(before=("create", "jec", "jer"), performs=("correction", "jec"))
     def redoJEC(self, JECDatabase=None, addBtagDiscriminators=None):
         """
         Redo the Jet Energy Corrections for the default AK4 jet collection,
@@ -286,11 +270,6 @@ class Framework(object):
 
         FIXME: Some love is needed for AK8 jets
         """
-
-        self.ensureNotCreated()
-
-        if self.__jer_done:
-            raise Exception("You must smear the jets after doing the Jet Energy Corrections. Please call 'redoJEC' before 'smearJets'")
 
         if self.verbose:
             print("")
@@ -328,14 +307,11 @@ class Framework(object):
 
         print("")
 
-        self.__jec_done = True
-
+    @dep(before=("create", "jer"), performs=("correction", "jer"))
     def smearJets(self, resolutionFile=None, scaleFactorFile=None):
         """
         Smear the jets
         """
-
-        self.ensureNotCreated()
 
         if self.isData:
             return
@@ -396,8 +372,7 @@ class Framework(object):
         if self.verbose:
             print("New jets and MET collections: %r and %r" % (self.__miniaod_jet_collection, self.__miniaod_met_collection))
 
-        self.__jer_done = True
-
+    @dep(before=("create", "muonScale"), performs=("correction", "muonScale"))
     def applyMuonCorrection(self, type):
         """
         Apply correction to muon
@@ -410,8 +385,6 @@ class Framework(object):
 
         if not type in supported:
             raise Exception("Unsupported muon correction. Can only be one of %s" % supported)
-
-        self.ensureNotCreated()
 
         if self.verbose:
             print("")
@@ -440,15 +413,12 @@ class Framework(object):
         if self.verbose:
             print("New muons collection: %r" % (self.__miniaod_muon_collection))
 
-        self.__muon_correction_done = True
-
+    @dep(before=("create", "eleReg"), performs=("correction", "eleReg"))
     def applyElectronRegression(self):
         """
         Apply electron regression from
             https://twiki.cern.ch/twiki/bin/view/CMS/EGMRegression
         """
-
-        self.ensureNotCreated()
 
         if self.verbose:
             print("")
@@ -473,22 +443,16 @@ class Framework(object):
         if self.verbose:
             print("New electrons collection: %r" % (self.__miniaod_electron_collection))
 
-        self.__electron_regression_done = True
-
+    @dep(before=("create", "eleSmear"), after="eleReg", performs=("eleSmear", "correction"))
     def applyElectronSmearing(self):
         """
         Apply electron smearing from
             https://twiki.cern.ch/twiki/bin/view/CMS/EGMSmearer
         """
 
-        self.ensureNotCreated()
-
         if self.verbose:
             print("")
             print("Applying electron smearing...")
-
-        if not self.__electron_regression_done:
-            print("Warning: electron regression is not applied. You probably want to call `applyElectronRegression()` before calling `applyElectronSmearing`")
 
         from EgammaAnalysis.ElectronTools.calibratedPatElectronsRun2_cfi import calibratedPatElectrons
         from EgammaAnalysis.ElectronTools.calibrationTablesRun2 import files
@@ -524,14 +488,11 @@ class Framework(object):
         if self.verbose:
             print("New electrons collection: %r" % (self.__miniaod_electron_collection))
 
-        self.__electron_smearing_done = True
-
+    @dep(before="create")
     def doSystematics(self, systematics, **kwargs):
         """
         Enable systematics
         """
-
-        self.ensureNotCreated()
 
         if self.isData:
             return
@@ -544,13 +505,8 @@ class Framework(object):
     # Private methods
     #
 
-    def ensureNotCreated(self):
-        if self.__created:
-            raise RuntimeError("The framework configuration is frozen. Framework.create() must be the last function called.")
-
+    @dep(before="create")
     def configureElectronId_(self):
-
-        self.ensureNotCreated()
 
         with StdStreamSilenter():
             from PhysicsTools.SelectorUtils.tools.vid_id_tools import DataFormat, switchOnVIDElectronIdProducer, setupAllVIDIdsInModule, setupVIDElectronSelection
@@ -571,9 +527,8 @@ class Framework(object):
 
             self.process.electronMVAValueMapProducer.srcMiniAOD = self.__miniaod_electron_collection
 
+    @dep(before="configure", performs="configure")
     def configureFramework_(self):
-
-        self.ensureNotCreated()
 
         from cp3_llbb.Framework import EventProducer
         from cp3_llbb.Framework import GenParticlesProducer

--- a/python/Framework.py
+++ b/python/Framework.py
@@ -413,7 +413,7 @@ class Framework(object):
         if self.verbose:
             print("New muons collection: %r" % (self.__miniaod_muon_collection))
 
-    @dep(before=("create", "eleReg"), performs=("correction", "eleReg"))
+    @dep(before=("create", "electronRegression"), performs=("correction", "electronRegression"))
     def applyElectronRegression(self):
         """
         Apply electron regression from
@@ -443,7 +443,7 @@ class Framework(object):
         if self.verbose:
             print("New electrons collection: %r" % (self.__miniaod_electron_collection))
 
-    @dep(before=("create", "eleSmear"), after="eleReg", performs=("eleSmear", "correction"))
+    @dep(before=("create", "electronSmearing"), after="electronRegression", performs=("electronSmearing", "correction"))
     def applyElectronSmearing(self):
         """
         Apply electron smearing from

--- a/python/Framework.py
+++ b/python/Framework.py
@@ -92,7 +92,7 @@ class Framework(object):
 
         self._configureFramework()
 
-    @dep(before="create", performs="create", fallback=lambda self : self.process)
+    @dep(before="create", performs="create")
     def create(self):
         """
         Terminate the process configuration and return the final CMSSW process

--- a/python/Systematics.py
+++ b/python/Systematics.py
@@ -4,6 +4,8 @@ import FWCore.ParameterSet.Config as cms
 
 from cp3_llbb.Framework.Tools import change_input_tags_and_strings, module_has_string
 
+framework_skipDepChecks = ("correction",)
+
 class Systematics(object):
     def __init__(self, name, framework):
         self.name = name
@@ -66,8 +68,8 @@ class JetsSystematics(Systematics):
         cfg.parameters.jets = cms.untracked.InputTag(inputCollection)
         cfg.parameters.systematics = cms.untracked.bool(True)
        
-        index = self.framework.getProducerIndex('jets')
-        self.framework.addProducer(producerName, cfg, index + 1)
+        index = self.framework.getProducerIndex('jets', skipDepsCheck=framework_skipDepChecks)
+        self.framework.addProducer(producerName, cfg, index + 1, skipDepsCheck=framework_skipDepChecks)
 
     def addMETProducer(self, inputCollection, postfix):
         producerName = self.formatModuleVariableName('met', postfix)
@@ -79,8 +81,8 @@ class JetsSystematics(Systematics):
         cfg.parameters.slimmed = cms.untracked.bool(False)
         cfg.parameters.systematics = cms.untracked.bool(True)
        
-        index = self.framework.getProducerIndex('met')
-        self.framework.addProducer(producerName, cfg, index + 1)
+        index = self.framework.getProducerIndex('met', skipDepsCheck=framework_skipDepChecks)
+        self.framework.addProducer(producerName, cfg, index + 1, skipDepsCheck=framework_skipDepChecks)
 
     def run(self):
         upModules = self.getJetSystematicsProducers_(+1)
@@ -159,9 +161,9 @@ class JetsSystematics(Systematics):
                 upCfg.prefix = self.formatModuleVariableName(upCfg.prefix.value(), upModulePostfix) + '_'
                 downCfg.prefix = self.formatModuleVariableName(downCfg.prefix.value(), downModulePostfix) + '_'
 
-                index = self.framework.getAnalyzerIndex(analyzer)
-                self.framework.addAnalyzer(upAnalyzer, upCfg, index + 1)
-                self.framework.addAnalyzer(downAnalyzer, downCfg, index + 2)
+                index = self.framework.getAnalyzerIndex(analyzer, skipDepsCheck=framework_skipDepChecks)
+                self.framework.addAnalyzer(upAnalyzer, upCfg, index + 1, skipDepsCheck=framework_skipDepChecks)
+                self.framework.addAnalyzer(downAnalyzer, downCfg, index + 2, skipDepsCheck=framework_skipDepChecks)
 
 
 class JECSystematics(JetsSystematics):

--- a/python/deptracker.py
+++ b/python/deptracker.py
@@ -8,15 +8,15 @@ class deptracker(object):
     Basic dependency tracking for member methods of an object, using a decorator class
 
     The member methods can e.g. be decorated as follows:
-    >>> @deptracker(before=("create", "eleSmear"), after="eleReg", performs=("eleSmear", "correction"))
+    >>> @deptracker(before=("create", "electronSmearing"), after="electronRegression", performs=("electronSmearing", "correction"))
     >>> def applyElectronSmearing(self):
     >>>     ...
 
     which will, when calling this method, check that no member method with `@deptracker(..., performs=("create"))`
-    nor `@deptracker(..., performs=("eleSmear"))` has been called yet, and
-    that a method with `@deptracker(..., performs=("eleReg", ...))` has been called.
-    Furthermore, this will mark "eleSmear" and "correction" as "done", such that no other method
-    with either of these in "before" can be called after (for "eleSmear": including this method;
+    nor `@deptracker(..., performs=("electronSmearing"))` has been called yet, and
+    that a method with `@deptracker(..., performs=("electronRegression", ...))` has been called.
+    Furthermore, this will mark "electronSmearing" and "correction" as "done", such that no other method
+    with either of these in "before" can be called after (for "electronSmearing": including this method;
     putting the same tag in "before" and "after" ensures that a method is called no more than once).
 
     This is implemented using a "__trackers" dictionary that is added to the object's attributes.

--- a/python/deptracker.py
+++ b/python/deptracker.py
@@ -21,11 +21,10 @@ class deptracker(object):
 
     This is implemented using a "__trackers" dictionary that is added to the object's attributes.
     """
-    def __init__(self, before=None, after=None, performs=None, fallback=None):
+    def __init__(self, before=None, after=None, performs=None):
         self.before   = deptracker._parse_names(before  )
         self.after    = deptracker._parse_names(after   )
         self.performs = deptracker._parse_names(performs)
-        self.fallback = fallback
     @staticmethod
     def _parse_names(arg):
         names = tuple()
@@ -60,14 +59,10 @@ class deptracker(object):
             deco.checkInit(self)
             if not unchecked:
                 if any(deco.isDone(self, step) and step not in unchecked for step in deco.before):
-                    if deco.fallback:
-                        return deco.fallback(*args, **kwargs)
                     raise RuntimeError("Method {0} called after performing {1}".format(func.__name__
                         , ", ".join(step for step in deco.before if deco.isDone(self, step))
                         ))
                 if any(( not deco.isDone(self, step) ) and step not in unchecked for step in deco.after):
-                    if deco.fallback:
-                        return deco.fallback(*args, **kwargs)
                     raise RuntimeError("Method {0} called before performing {1}".format(func.__name__
                         , ", ".join(step for step in deco.after if not deco.isDone(self, step))
                         ))

--- a/python/deptracker.py
+++ b/python/deptracker.py
@@ -1,0 +1,86 @@
+from itertools import imap, chain
+from functools import wraps
+
+__all__ = ("deptracker",)
+
+class deptracker(object):
+    """
+    Basic dependency tracking for member methods of an object, using a decorator class
+
+    The member methods can e.g. be decorated as follows:
+    >>> @deptracker(before=("create", "eleSmear"), after="eleReg", performs=("eleSmear", "correction"))
+    >>> def applyElectronSmearing(self):
+    >>>     ...
+
+    which will, when calling this method, check that no member method with `@deptracker(..., performs=("create"))`
+    nor `@deptracker(..., performs=("eleSmear"))` has been called yet, and
+    that a method with `@deptracker(..., performs=("eleReg", ...))` has been called.
+    Furthermore, this will mark "eleSmear" and "correction" as "done", such that no other method
+    with either of these in "before" can be called after (for "eleSmear": including this method;
+    putting the same tag in "before" and "after" ensures that a method is called no more than once).
+
+    This is implemented using a "__trackers" dictionary that is added to the object's attributes.
+    """
+    def __init__(self, before=None, after=None, performs=None, fallback=None):
+        self.before   = deptracker._parse_names(before  )
+        self.after    = deptracker._parse_names(after   )
+        self.performs = deptracker._parse_names(performs)
+        self.fallback = fallback
+    @staticmethod
+    def _parse_names(arg):
+        from itertools import imap
+        names = tuple()
+        if isinstance(arg, str):
+            names = (arg,)
+        elif hasattr(arg, "__iter__"):
+            names = arg
+        return tuple(imap(deptracker._varName, names))
+    @staticmethod
+    def _varName(name):
+        return "__{}_done".format(name)
+    @staticmethod
+    def _actionName(varName):
+        return varName[2:-5]
+
+    def checkInit(self, obj):
+        """ ensure that the tracker dictionary is there, and our keys are present """
+        if not hasattr(obj, "_trackers"):
+            setattr(obj, "_trackers", dict())
+        from itertools import chain
+        for nm in chain(self.before, self.after, self.performs):
+            if nm not in obj._trackers:
+                obj._trackers[nm] = False
+    @staticmethod
+    def isDone(obj, name):
+        """ has this action been performed for this instance? """
+        return obj._trackers[name]
+    @staticmethod
+    def setDone(obj, name):
+        """ mark this action done for this instance """
+        obj._trackers[name] = True
+
+    def __call__(deco, func):
+        @wraps(func)
+        def func_wrapper(*args, **kwargs):
+            self = args[0]
+            deco.checkInit(self)
+            if any(deco.isDone(self, step) for step in deco.before):
+                if deco.fallback:
+                    return deco.fallback(*args, **kwargs)
+                raise RuntimeError("Method {0} called after performing {1}".format(func.__name__
+                    , ", ".join(deptracker._actionName(step) for step in deco.before if deco.isDone(self, step))
+                    ))
+            if any(not deco.isDone(self, step) for step in deco.after):
+                if deco.fallback:
+                    return deco.fallback(*args, **kwargs)
+                raise RuntimeError("Method {0} called before performing {1}".format(func.__name__
+                    , ", ".join(deptracker._actionName(step) for step in deco.after if not deco.isDone(self, step))
+                    ))
+
+            ret = func(*args, **kwargs)
+
+            for nm in deco.performs:
+                deco.setDone(self, nm)
+
+            return ret
+        return func_wrapper

--- a/python/deptracker.py
+++ b/python/deptracker.py
@@ -28,19 +28,12 @@ class deptracker(object):
         self.fallback = fallback
     @staticmethod
     def _parse_names(arg):
-        from itertools import imap
         names = tuple()
         if isinstance(arg, str):
             names = (arg,)
         elif hasattr(arg, "__iter__"):
             names = arg
-        return tuple(imap(deptracker._varName, names))
-    @staticmethod
-    def _varName(name):
-        return "__{}_done".format(name)
-    @staticmethod
-    def _actionName(varName):
-        return varName[2:-5]
+        return tuple(names)
 
     def checkInit(self, obj):
         """ ensure that the tracker dictionary is there, and our keys are present """
@@ -68,13 +61,13 @@ class deptracker(object):
                 if deco.fallback:
                     return deco.fallback(*args, **kwargs)
                 raise RuntimeError("Method {0} called after performing {1}".format(func.__name__
-                    , ", ".join(deptracker._actionName(step) for step in deco.before if deco.isDone(self, step))
+                    , ", ".join(step for step in deco.before if deco.isDone(self, step))
                     ))
             if any(not deco.isDone(self, step) for step in deco.after):
                 if deco.fallback:
                     return deco.fallback(*args, **kwargs)
                 raise RuntimeError("Method {0} called before performing {1}".format(func.__name__
-                    , ", ".join(deptracker._actionName(step) for step in deco.after if not deco.isDone(self, step))
+                    , ", ".join(step for step in deco.after if not deco.isDone(self, step))
                     ))
 
             ret = func(*args, **kwargs)


### PR DESCRIPTION
implemented using a decorator class with "before", "after" and
"performs" tag lists, which will enforce none of "before" flags has been
set yet, all of the "after" flags have been set, and set the "performs"
flags to True.

There are some limitations to the scaling of this, but I wanted to keep it reasonably light (both the implementation and amount of annotations to add) - feel free to try and break it from your config by doing things in the wrong order ;-) . It should enforce that adding/removing analyzers&producers can only be done before any of the corrections, as well as the orderings (JEC only before JER, electron smearing needs regression) that were already checked for.