### PR TITLE
Allow building BinnedValues(JSONParser) as a standalone library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.lo
 *.o
 *.obj
+*.d
 
 # Precompiled Headers
 *.gch

--- a/Makefile.libBinnedValues
+++ b/Makefile.libBinnedValues
@@ -1,0 +1,56 @@
+## adapted from plotIt/Makefile
+
+ObjSuf = o
+SrcSuf = cc
+DllSuf = so
+
+ROOTCFLAGS = $(shell root-config --cflags)
+ROOTLIBS   = $(shell root-config --noldflags --libs)
+BOOST_ROOT = $(shell scram tool tag boost BOOST_BASE)
+
+CXXFLAGS = -g -Wall -fPIC --std=c++11 -O3 -DSTANDALONE_SCALEFACTORS
+LD       = $(CXX)
+LDDIR    = -L$(shell root-config --libdir) -L$(BOOST_ROOT)/lib/
+LDFLAGS  = -fPIC $(shell root-config --ldflags) $(LDDIR)
+SOFLAGS  =
+AR       = ar
+ARFLAGS  = -cq
+
+CXXFLAGS    += $(ROOTCFLAGS) $(INCLUDES) -I../.. -I$(shell echo $(BOOST_ROOT))/include ## assume to be in cp3_llbb/Framework
+LIBS        = $(ROOTLIBS) ## TODO get the right ones from boost
+STATIC_LIBS =
+#------------------------------------------------------------------------------
+SOURCES     = src/BinnedValues.cc src/BinnedValuesJSONParser.cc
+OBJECTS     = $(SOURCES:.$(SrcSuf)=.$(ObjSuf))
+DEPENDS     = $(SOURCES:.$(SrcSuf)=.d)
+
+.SUFFIXES: .$(SrcSuf) .$(ObjSuf)
+
+###
+
+all: print_deps libBinnedValues.$(DllSuf)
+
+print_deps:
+	@echo "Building BinnedValuseJSONParser library with Boost and ROOT from current CMSSW environment..."
+	@echo "Using ROOT from $(shell root-config --prefix)"
+	@echo "Using Boost from $(shell scram tool tag boost BOOST_BASE)"
+
+clean:
+	@rm -f $(OBJECTS);
+	@rm -f $(DEPENDS);
+
+libBinnedValues.$(DllSuf): $(OBJECTS)
+	@echo "Linking $@..."
+	@$(LD) -shared $(SOFLAGS) $(LDFLAGS) $+ -o $@ -Wl,-Bstatic $(STATIC_LIBS) -Wl,-Bdynamic $(LIBS)
+
+%.o: %.cc
+	@echo "Compiling $<..."
+	@$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+# Make the dependencies
+%.d: %.cc
+	@ $(CXX) $(CXXFLAGS) -MM $< | sed -e 's@^\(.*\)\.o:@src/\1.d src/\1.o:@' > $@
+
+ifneq ($(MAKECMDGOALS), clean)
+-include $(DEPENDS)
+endif

--- a/interface/BTaggingScaleFactors.h
+++ b/interface/BTaggingScaleFactors.h
@@ -1,11 +1,6 @@
 #pragma once
 
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <FWCore/Framework/interface/Event.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/ConsumesCollector.h>
-#include <FWCore/Utilities/interface/InputTag.h>
-#include <DataFormats/Common/interface/ValueMap.h>
 #include <FWCore/Utilities/interface/EDMException.h>
 
 #include <cp3_llbb/Framework/interface/Histogram.h>

--- a/interface/BinnedValues.h
+++ b/interface/BinnedValues.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <sstream>
 
 #include <TFormula.h>
 

--- a/interface/BinnedValuesJSONParser.h
+++ b/interface/BinnedValuesJSONParser.h
@@ -1,12 +1,5 @@
 #pragma once
 
-#include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <FWCore/Framework/interface/Event.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/ConsumesCollector.h>
-#include <FWCore/Utilities/interface/InputTag.h>
-#include <DataFormats/Common/interface/ValueMap.h>
-
 #include <cp3_llbb/Framework/interface/Histogram.h>
 #include <cp3_llbb/Framework/interface/BinnedValues.h>
 

--- a/interface/ScaleFactors.h
+++ b/interface/ScaleFactors.h
@@ -1,11 +1,6 @@
 #pragma once
 
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <FWCore/Framework/interface/Event.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/ConsumesCollector.h>
-#include <FWCore/Utilities/interface/InputTag.h>
-#include <DataFormats/Common/interface/ValueMap.h>
 
 #include <cp3_llbb/Framework/interface/Histogram.h>
 #include <cp3_llbb/Framework/interface/BinnedValues.h>

--- a/src/BinnedValues.cc
+++ b/src/BinnedValues.cc
@@ -1,6 +1,8 @@
 #include <cp3_llbb/Framework/interface/BinnedValues.h>
 
+#ifndef STANDALONE_SCALEFACTORS
 #include <FWCore/Utilities/interface/EDMException.h>
+#endif
 
 Parameters::Parameters(Parameters&& rhs) {
     m_values = std::move(rhs.m_values);
@@ -49,9 +51,14 @@ std::vector<float> Parameters::toArray(const std::vector<BinningVariable>& binni
     for (const auto& bin: binning) {
         const auto& it = m_values.find(bin);
         if (it == m_values.cend()) {
-            throw edm::Exception(edm::errors::NotFound, "Parametrisation depends on '" + 
+            std::string message{"Parametrisation depends on '" +
                     BinnedValues::variable_to_string_mapping.left.at(bin) +
-                    "' but no value for this parameter has been specified. Please call the appropriate 'set' function of the Parameters object");
+                    "' but no value for this parameter has been specified. Please call the appropriate 'set' function of the Parameters object"};
+#ifdef STANDALONE_SCALEFACTORS
+            throw std::invalid_argument(message);
+#else
+            throw edm::Exception(edm::errors::NotFound, message);
+#endif
         }
 
         values.push_back(it->second);

--- a/src/BinnedValuesJSONParser.cc
+++ b/src/BinnedValuesJSONParser.cc
@@ -1,6 +1,10 @@
+#include <boost/property_tree/json_parser.hpp>
+
 #include <cp3_llbb/Framework/interface/BinnedValuesJSONParser.h>
 
-#include <boost/property_tree/json_parser.hpp>
+#ifndef STANDALONE_SCALEFACTORS
+#include <FWCore/Utilities/interface/EDMException.h>
+#endif
 
 void BinnedValuesJSONParser::parse_file(const std::string& file) {
 
@@ -11,7 +15,12 @@ void BinnedValuesJSONParser::parse_file(const std::string& file) {
 
     std::vector<std::string> variables = get_string_array(ptree.get_child("variables"));
     if (variables.size() != dimension) {
-        throw edm::Exception(edm::errors::LogicError, "Invalid number of variables. Expected " + std::to_string(dimension) + ", got " + std::to_string(variables.size()));
+        std::string message{"Invalid number of variables. Expected " + std::to_string(dimension) + ", got " + std::to_string(variables.size())};
+#ifdef STANDALONE_SCALEFACTORS
+        throw std::logic_error(message);
+#else
+        throw edm::Exception(edm::errors::LogicError, message);
+#endif
     }
 
     std::vector<float> binning_x = get_array(ptree.get_child("binning.x"));
@@ -37,8 +46,14 @@ void BinnedValuesJSONParser::parse_file(const std::string& file) {
             m_values.formula_variable_index = 1;
         else if (variable == "z")
             m_values.formula_variable_index = 2;
-        else
-            throw edm::Exception(edm::errors::LogicError, "Unsupported variable: " + variable);
+        else {
+            std::string message{"Unsupported variable: " + variable};
+#ifdef STANDALONE_SCALEFACTORS
+            throw std::logic_error(message);
+#else
+            throw edm::Exception(edm::errors::LogicError, message);
+#endif
+        }
     }
 
     m_values.maximum = ptree.get("maximum", std::numeric_limits<float>::max());


### PR DESCRIPTION
Changing to CMSSW_8_0_30, I noticed that I had not upstreamed these changes yet... the reason to build a library from BinnedValues and BinnedValuesJSONParser that doesn't depend on CMSSW is that I can then more easily link my plotter to this one instead of copying the code :-) (I apply SFs at that stage). I know ifdef's are not nice... but I hope these are few and hidden enough to be acceptable ;-) (they are only in the cc files).
I also removed some includes from ScaleFactors.h and BTaggingScaleFactors.h, but those should not be affected - it's only because I saw the same list in three places, so probably they've been copied around before.